### PR TITLE
feat: port 4 DCN AI Intelligence capabilities (correlation, RCA KB, triage, patterns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ netlog-ai mcp        # stdio transport — wire into Claude Code, Cursor, Contin
 ```
 
 Tools exposed: `list_sources`, `add_source`, `fetch_logs`, `search_logs`,
-`analyze_logs`, `get_top_offenders`, `list_sites`, `analyze_site`, plus
-healthcheck + connector inventory. See [docs/CONNECTORS.md](docs/CONNECTORS.md)
-for the full reference.
+`analyze_logs`, `get_top_offenders`, `correlate_sources`, `analyze_device`,
+`list_sites`, `analyze_site`, plus healthcheck + connector inventory. See
+[docs/CONNECTORS.md](docs/CONNECTORS.md) for the full reference.
 
 ## Features
 
@@ -64,6 +64,8 @@ for the full reference.
 |---|---|
 | 🔌 **Pluggable sources** | Kibana, Splunk, Loki, LibreNMS, syslog UDP/TCP — one Protocol, one config dict, hot-pluggable |
 | 🤖 **MCP server mode** | Claude Code / Cursor / Continue can call the analyzer directly as agent tools |
+| 🔗 **Cross-source correlation** | **Device tab** → *Correlate Sources*: scans every registered source and tags each host `confirmed` (flagged by ≥ 2 sources) or `suspected` (1) in a sortable, severity-coded table |
+| 🔬 **Per-device triage** | **Device tab** → *Triage Device*: one host's verdict + 0–100 health score, severity histogram, top processes, and deduped error patterns in a single panel |
 | 🔎 **Classify** | 50+ regex patterns across Junos, EOS, FRR, IOS, RFC-3164/5424 |
 | 🧭 **Prioritize** | Deduped action items, ranked by severity × count, recovery events excluded |
 | 🧠 **Deep analyze** | Top-N items get an LLM-written root-cause + risk + remediation playbook |
@@ -348,6 +350,8 @@ src/ai_log_analyzer/
 | `POST` | `/api/optimize` | Device-level config audit + patches |
 | `POST` | `/api/optimize/site` | Cross-device site analysis |
 | `POST` | `/api/optimize/site-wide/<id>` | Strategic maturity scoring + phased roadmap |
+| `POST` | `/api/correlate` | Cross-source correlation — confirmed (≥ 2 sources) vs suspected (1) devices |
+| `POST` | `/api/triage` | Per-device triage — verdict, health score, severity histogram, top processes, patterns |
 | `GET`  | `/api/topology/<id>` | Topology graph (JSON / Mermaid / DOT) |
 | `GET`  | `/api/compliance/<id>` | Compliance rules pass/fail |
 | `POST` | `/api/copilot` | Free-form Q&A grounded in selected site config |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,17 @@ See [`docs/TFSM_AUTO_PARSER.md`](docs/TFSM_AUTO_PARSER.md) for the API, scoring 
 and filter-hint reference. The full WebM video is [`demo/tfsm_demo.webm`](demo/tfsm_demo.webm)
 (19s, 311 KB) and the recording is reproducible via [`demo/record_tfsm_demo.sh`](demo/record_tfsm_demo.sh).
 
+## DCN AI port — correlation, triage, and expanded KB (2026-06-02)
+
+Four capabilities backfilled from the closed-source DCN AI Intelligence Center:
+
+- **Multi-source correlation** — `correlate_sources` MCP tool classifies events from every registered source and tags each device `confirmed` (seen in ≥ 2 independent sources) or `suspected` (1 source only). Eliminates single-source noise before escalation.
+- **Richer RCA KB** — every KB entry (`bgp`, `ospf`, `interface`, `lag`, `hardware`, `compliance`, `security`, `system`) now carries a structured `rca` block: numbered root-cause list, risk sentence, ordered resolution steps, and copy-pastable Junos / EOS CLI commands. Two new categories added: `vpn` (IKE/IPsec failure) and `redundancy` (VRRP/HSRP failover); `hardware` extended with `fpc` (line-card errors) and `chassis` (PSU/fan/temperature alarms).
+- **Expanded classifier patterns** — `inetd|xinetd|ftpd` added as a low-severity `system` pattern, positioned after all high-severity patterns so first-match-wins is preserved. Three new unit tests confirm matching and priority ordering.
+- **Per-device triage** — `analyze_device` MCP tool pulls one hostname's events from all sources, returns a severity histogram, process breakdown, frequency-deduped error patterns, a KB verdict (e.g. `ROUTING`, `HARDWARE`), and a 0–100 health score.
+
+Full details and usage examples: [`docs/PORTED_FROM_DCN_AI.md`](docs/PORTED_FROM_DCN_AI.md).
+
 ## LOGS pipeline hardening (2026-05-27)
 
 Three follow-up fixes to the LOGS tab: (1) the Executive Summary LLM call now

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ pipeline orchestrator, and the pluggable intelligence backends (LLM client and r
 ```mermaid
 flowchart TB
     subgraph ENTRY["Entrypoints"]
-        WEB["web/ - Flask plus vanilla-JS SPA, port 6060, ~28 api routes"]
+        WEB["web/ - Flask plus vanilla-JS SPA, port 6060, ~30 api routes"]
         CLI["cli.py - serve, analyze, mcp"]
         MCP["mcp_server/ - FastMCP stdio"]
     end

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -113,18 +113,20 @@ netlog-ai mcp --transport streamable-http
 
 ### Tools exposed
 
-| Tool                    | Purpose |
-|-------------------------|---------|
-| `list_connector_kinds`  | Enumerate built-in connector types |
-| `list_sources`          | Show registered live sources |
-| `add_source`            | Register a new connector at runtime |
-| `test_source`           | Healthcheck a registered source |
-| `fetch_logs`            | Pull raw events from a source |
-| `search_logs`           | Pull events matching a regex pattern |
-| `analyze_logs`          | Full analyzer pipeline (classify + dedup + rank + optional LLM) |
-| `get_top_offenders`     | Return the N noisiest hostnames |
-| `list_sites`            | Enumerate bundled site directories |
-| `analyze_site`          | Run site-wide cross-device analysis |
+| Tool                   | Purpose                                                                              |
+|------------------------|--------------------------------------------------------------------------------------|
+| `list_connector_kinds` | Enumerate built-in connector types                                                   |
+| `list_sources`         | Show registered live sources                                                         |
+| `add_source`           | Register a new connector at runtime                                                  |
+| `test_source`          | Healthcheck a registered source                                                      |
+| `fetch_logs`           | Pull raw events from a source                                                        |
+| `search_logs`          | Pull events matching a regex pattern                                                 |
+| `analyze_logs`         | Full analyzer pipeline (classify + dedup + rank + optional LLM)                      |
+| `get_top_offenders`    | Return the N noisiest hostnames                                                      |
+| `correlate_sources`    | Cross-source correlation: marks devices confirmed (2+ sources) or suspected (1)      |
+| `analyze_device`       | Per-device triage: histogram, process breakdown, KB verdict, 0-100 health score      |
+| `list_sites`           | Enumerate bundled site directories                                                   |
+| `analyze_site`         | Run site-wide cross-device analysis                                                  |
 
 ### Hook into Claude Code
 

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -94,6 +94,11 @@ export NETLOG_SOURCE_librenms_API_TOKEN=...
 | POST   | `/api/sources/<id>/test`              | Healthcheck a source |
 | POST   | `/api/sources/<id>/fetch`             | Pull raw events `{since_seconds, limit, host_filter}` |
 | POST   | `/api/sources/<id>/analyze`           | Pull + run full analyzer pipeline (auth-required) |
+| POST   | `/api/correlate`                      | Cross-source correlation — confirmed (≥ 2 sources) vs suspected (1) devices (auth-required) |
+| POST   | `/api/triage`                         | Per-device triage — verdict, health score, histogram, processes, patterns (auth-required) |
+
+The last two are the HTTP surface (Device tab in the SPA) of the same capability
+exposed to agents by the `correlate_sources` / `analyze_device` MCP tools below.
 
 ---
 

--- a/docs/PORTED_FROM_DCN_AI.md
+++ b/docs/PORTED_FROM_DCN_AI.md
@@ -5,6 +5,10 @@ Four capabilities backfilled from the closed-source **DCN AI Intelligence Center
 same cross-source correlation and per-device triage patterns that operate against
 real Kibana/LibreNMS feeds into the open-source, lab-portable tool.
 
+Both correlation and triage are now reachable **two ways**: as the agent-facing MCP
+tools documented below (`correlate_sources`, `analyze_device`) and as first-class
+**Web GUI** surfaces in the Device tab of the SPA — see [Web GUI surface](#web-gui-surface).
+
 ---
 
 ## 1. Multi-source correlation (`correlate_sources`)
@@ -170,4 +174,26 @@ analyze_device(hostname="fra4-rt-01", source_ids=["kibana"])
 | `src/ai_log_analyzer/classifier.py` | +1 pattern (`inetd\|xinetd\|ftpd`) |
 | `src/ai_log_analyzer/kb.py` | Richer `rca` blocks on all existing entries; new `_VPN_DOWN`, `_REDUNDANCY`, `_FPC_ERR`, `_CHASSIS_ENV` entries; `hardware` sub-tree extended; `vpn` and `redundancy` keys added to `KB` dict |
 | `src/ai_log_analyzer/mcp_server/server.py` | +2 tools: `correlate_sources`, `analyze_device` |
+| `src/ai_log_analyzer/web/app.py` | +2 routes: `POST /api/correlate`, `POST /api/triage` (thin wrappers over `correlate_from_manager` / `triage_from_manager`) |
+| `src/ai_log_analyzer/web/static/index.html` | Device-tab controls + result panels for the Correlate / Triage GUI |
+| `src/ai_log_analyzer/web/static/app.js` | Handlers + renderers for the correlation table and triage panel |
 | `tests/test_classifier.py` | +3 unit tests for the new inetd pattern |
+| `tests/test_web_correlate_triage.py` | Route-wrapper tests for `/api/correlate` and `/api/triage` |
+
+---
+
+## Web GUI surface
+
+The correlation and triage capabilities are no longer MCP-only — both now have a
+front-end home in the **Device tab** of the SPA, alongside *Optimize Device*:
+
+- **🔗 Correlate Sources** (`POST /api/correlate`, wrapping `correlate_from_manager`) —
+  a sidebar control (min-severity + time window) renders a sortable, severity-coded
+  table of devices, each tagged **CONFIRMED** (≥ 2 sources) or **SUSPECTED** (1), with
+  per-source coverage pips and a per-row *Triage* button.
+- **🔬 Triage Device** (`POST /api/triage`, wrapping `triage_from_manager`) — a hostname
+  input opens a result panel with a status-colored verdict banner, a 0–100 health-score
+  ring, a severity histogram, a top-process table, and the deduped error patterns.
+
+These are the GUI front-ends of the same `correlate_sources` / `analyze_device` tools
+above; the routes are pure thin wrappers and add no business logic.

--- a/docs/PORTED_FROM_DCN_AI.md
+++ b/docs/PORTED_FROM_DCN_AI.md
@@ -1,0 +1,173 @@
+# Port from DCN AI Intelligence Center — 2026-06-02
+
+Four capabilities backfilled from the closed-source **DCN AI Intelligence Center**
+(`04_Scripts_Tools/DCN_AI_Intelligence`) into netlog-ai. The goal was to bring the
+same cross-source correlation and per-device triage patterns that operate against
+real Kibana/LibreNMS feeds into the open-source, lab-portable tool.
+
+---
+
+## 1. Multi-source correlation (`correlate_sources`)
+
+**What changed:** `src/ai_log_analyzer/correlate.py` (pre-existing) is now callable
+from the MCP layer via `correlate_from_manager()`. The function classifies events from
+every registered source, then tags each device as:
+
+- **confirmed** — actionable events (severity ≥ `min_severity`) appear in **two or
+  more** independent sources (e.g. Kibana *and* LibreNMS both report the same host).
+- **suspected** — only one source has seen the device.
+
+The double-source requirement eliminates single-source noise (a syslog burst that
+didn't trigger a LibreNMS alert is unlikely to be a real incident).
+
+## 2. Richer root-cause KB (`kb.py`)
+
+**What changed:** every existing KB entry (`BGP_DOWN`, `OSPF_ADJ`, `INT_DOWN`,
+`LAG_DOWN`, `ASIC_PARITY`, `LICENSE`, `AUTH_FAIL`, `KERNEL_PANIC`) gained a
+structured `rca` sub-dict with:
+
+- `root_cause` — plain-English diagnosis, numbered cause list
+- `risk` — traffic-impact sentence
+- `resolution_steps` — ordered checklist (5–8 items)
+- `cli_junos` / `cli_eos` — copy-pastable command sets for both vendors
+- `timeline` — P1/P2 priority with a time-to-act statement
+
+Two entirely new KB categories were added from the DCN AI KB:
+
+| Category key | Match pattern | Covers |
+|---|---|---|
+| `vpn` / `tunnel_down` | `ike\|ipsec\|vpn\|tunnel` | IKE Phase 1/2 failure, NAT-T, cert expiry, UDP 500/4500 |
+| `redundancy` / `failover` | `vrrp\|hsrp\|failover\|master.*change` | VRRP/HSRP state change, split-brain, tracked-object events |
+
+Both entries include the full 5-phase playbook (Diagnose → Mitigate → Remediate →
+Verify → Optimize), `preventive_config` snippets, and `monitoring` alert guidance.
+
+The `hardware` KB sub-tree also gained two entries (`fpc`, `chassis`) alongside the
+existing `asic_parity` entry:
+
+| Sub-key | Match | Covers |
+|---|---|---|
+| `fpc` | `fpc.*(?:offline\|crash\|error\|halt\|restart)\|line.?card` | FPC/line-card offline, memory exhaustion, JTAC evidence collection |
+| `chassis` | `chassis.*alarm\|power.*fail\|fan.*fail\|psu\|temperature` | PSU failure, fan failure, thermal thresholds |
+
+## 3. Expanded classifier patterns (`classifier.py`)
+
+**What changed:** one pattern added to `_KB_PATTERNS` (low-severity, `system`
+category):
+
+```python
+(r"inetd|xinetd|ftpd", "low", "system", "inetd service activity"),
+```
+
+The entry is positioned *after* all higher-severity patterns (BGP, OSPF, interface,
+hardware) so the first-match-wins rule still lets a message that contains both an
+`ftpd` token and a `bgp.*down` token be classified by the routing pattern. Three new
+unit tests (`test_classifier.py`) verify the match, the parametrized `xinetd`/`ftpd`
+variants, and the first-match-wins invariant.
+
+## 4. Per-device triage (`analyze_device`)
+
+**What changed:** `src/ai_log_analyzer/device_triage.py` (pre-existing) is now
+callable from the MCP layer via `triage_from_manager()`. For a named hostname the
+function returns:
+
+- **severity histogram** across all registered sources
+- **process breakdown** — top appnames generating events
+- **frequency-deduped error patterns** — distinct message signatures sorted by count
+- **verdict** — the dominant KB category (e.g. `HARDWARE`, `ROUTING`, `LAG`)
+- **health score** — 0–100 integer; lower is worse
+
+---
+
+## New MCP tools
+
+Two tools were added to `src/ai_log_analyzer/mcp_server/server.py`.
+
+### `correlate_sources`
+
+Cross-source device correlation. Classifies each source's events independently,
+then marks devices `confirmed` or `suspected` based on how many sources saw them.
+
+**Signature:**
+
+```
+correlate_sources(
+    source_ids: list[str] | None = None,   # default: all registered sources
+    since_seconds: int = 3600,
+    limit: int = 5000,
+    min_severity: str = "medium",
+) -> dict
+```
+
+**Usage example** (Claude Code / MCP client):
+
+> "Use netlog-ai to correlate all sources for the last 2 hours and show me
+> every confirmed device."
+
+```python
+# Equivalent tool call
+correlate_sources(since_seconds=7200, min_severity="medium")
+# Returns:
+# {
+#   "ok": true,
+#   "confirmed": [{"hostname": "fra4-rt-01", "sources": ["kibana", "librenms"], ...}],
+#   "suspected": [{"hostname": "lhr3-sw-02", "sources": ["kibana"], ...}],
+# }
+```
+
+Filter to a specific pair of sources:
+
+```python
+correlate_sources(source_ids=["kibana", "librenms"], since_seconds=3600)
+```
+
+### `analyze_device`
+
+Per-device deep triage. Pulls one hostname's events from all (or specified) sources,
+builds a severity histogram, process breakdown, error pattern list, and returns a
+verdict + health score.
+
+**Signature:**
+
+```
+analyze_device(
+    hostname: str,
+    source_ids: list[str] | None = None,   # default: all registered sources
+    since_seconds: int = 86400,
+    limit: int = 5000,
+) -> dict
+```
+
+**Usage example:**
+
+> "Run a deep triage on fra4-rt-01 across all sources for the last 24 hours."
+
+```python
+analyze_device(hostname="fra4-rt-01", since_seconds=86400)
+# Returns:
+# {
+#   "hostname": "fra4-rt-01",
+#   "verdict": "ROUTING",
+#   "health_score": 42,
+#   "severity_histogram": {"high": 3, "medium": 11, "low": 74},
+#   "top_processes": [{"appname": "rpd", "count": 14}, ...],
+#   "error_patterns": [{"pattern": "bgp peer .* down", "count": 3}, ...],
+# }
+```
+
+Scope to a single source:
+
+```python
+analyze_device(hostname="fra4-rt-01", source_ids=["kibana"])
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/ai_log_analyzer/classifier.py` | +1 pattern (`inetd\|xinetd\|ftpd`) |
+| `src/ai_log_analyzer/kb.py` | Richer `rca` blocks on all existing entries; new `_VPN_DOWN`, `_REDUNDANCY`, `_FPC_ERR`, `_CHASSIS_ENV` entries; `hardware` sub-tree extended; `vpn` and `redundancy` keys added to `KB` dict |
+| `src/ai_log_analyzer/mcp_server/server.py` | +2 tools: `correlate_sources`, `analyze_device` |
+| `tests/test_classifier.py` | +3 unit tests for the new inetd pattern |

--- a/docs/index.html
+++ b/docs/index.html
@@ -359,7 +359,7 @@
           <div class="chip" role="listitem"><div class="num" data-count="55">0</div><div class="lbl">regex patterns</div></div>
           <div class="chip" role="listitem"><div class="num" data-count="5">0</div><div class="lbl">log connectors</div></div>
           <div class="chip" role="listitem"><div class="num" data-count="30">0</div><div class="lbl">demo devices</div></div>
-          <div class="chip" role="listitem"><div class="num" data-count="10">0</div><div class="lbl">MCP tools</div></div>
+          <div class="chip" role="listitem"><div class="num" data-count="12">0</div><div class="lbl">MCP tools</div></div>
         </div>
 
         <div class="cta-row">
@@ -843,7 +843,9 @@ pytest --cov=src --cov-report=term-missing</pre>
   const features = [
     { icon: "🛡️", title: "Sanitize-before-LLM gate", desc: "Every config/log payload is scrubbed of shadow hashes, Junos $9$, SSH keys, SNMP/RADIUS/TACACS+/IPsec keys, and public IPs (replaced with stable PUB-&lt;hash&gt; pseudonym tokens — a public IP is never sent to the LLM in clear text) before any outbound LLM call." },
     { icon: "🔌", title: "Pluggable log sources", desc: "Kibana, Splunk, Loki, LibreNMS, and a zero-config syslog UDP/TCP listener on port 5514 — one LogSource Protocol, one config dict, hot-pluggable." },
-    { icon: "🤖", title: "MCP server mode", desc: "The analyzer core is agent-callable over stdio from Claude Code / Cursor / Continue, exposing analyze_logs, fetch_logs, get_top_offenders, and analyze_site." },
+    { icon: "🤖", title: "MCP server mode", desc: "The analyzer core is agent-callable over stdio from Claude Code / Cursor / Continue, exposing analyze_logs, fetch_logs, get_top_offenders, correlate_sources, analyze_device, and analyze_site." },
+    { icon: "🔗", title: "Cross-source correlation", desc: "The Device tab's Correlate Sources view scans every registered source and tags each host confirmed (flagged by ≥ 2 independent sources) or suspected (1 only) in a sortable, severity-coded table — single-source noise is filtered before escalation." },
+    { icon: "🔬", title: "Per-device triage", desc: "The Device tab's Triage Device panel returns one host's verdict, a 0–100 health score ring, a severity histogram, top processes, and frequency-deduped error patterns in a single anchored view." },
     { icon: "🔎", title: "Multi-vendor classify & prioritize", desc: "55 regex patterns across Junos, Arista EOS, FRR, IOS and RFC-3164/5424 dedup into a severity × count ranked action list with recovery events excluded." },
     { icon: "🧠", title: "Local-first LLM, graceful fallback", desc: "Provider chain walks Ollama → Docker Model Runner → Anthropic Claude, then degrades to a deterministic rule-based KB so the tool never hard-fails on a missing model." },
     { icon: "🗺️", title: "Multi-layer topology", desc: "Cytoscape.js + ELK renders PHYSICAL, BGP, OSPF, and VXLAN as separate overlays on the same fabric, with AS/RID/VTEP on nodes and inferred link speed on edges." },
@@ -867,8 +869,8 @@ pytest --cov=src --cov-report=term-missing</pre>
     { name: "kb.py", tech: "Python", resp: "Rule-based deep-analysis knowledge base producing deterministic 5-phase playbooks when no LLM is available." },
     { name: "sources/", tech: "requests · typing.Protocol", resp: "Pluggable connector layer (LogSource Protocol + SourceManager): kibana, splunk, loki, syslog UDP/TCP listener, librenms — one config dict, hot-pluggable." },
     { name: "adapters/", tech: "subprocess (docker CLI) · TextFSM", resp: "Local ingest adapters: frr (docker logs → LogEvent), file (RFC3164/5424/Junos/freeform parser), network_tool, tfsm_auto (optional TextFSM auto-detect)." },
-    { name: "web/app.py", tech: "Flask 3 · vanilla JS · Cytoscape.js + ELK", resp: "Flask create_app() exposing ~29 API routes plus a no-build vanilla-JS SPA (index.html + app.js) on port 6060." },
-    { name: "mcp_server/server.py", tech: "MCP SDK (FastMCP) · stdio", resp: "Agent surface: FastMCP stdio server exposing list_sources, add_source, fetch_logs, search_logs, analyze_logs, get_top_offenders, list_sites, analyze_site + healthcheck/inventory." },
+    { name: "web/app.py", tech: "Flask 3 · vanilla JS · Cytoscape.js + ELK", resp: "Flask create_app() exposing ~31 API routes (incl. /api/correlate and /api/triage — the Device-tab cross-source correlation and per-device triage surfaces) plus a no-build vanilla-JS SPA (index.html + app.js) on port 6060." },
+    { name: "mcp_server/server.py", tech: "MCP SDK (FastMCP) · stdio", resp: "Agent surface: FastMCP stdio server exposing list_sources, add_source, fetch_logs, search_logs, analyze_logs, get_top_offenders, correlate_sources, analyze_device, list_sites, analyze_site + healthcheck/inventory." },
     { name: "cli.py", tech: "Python argparse", resp: "Console entrypoint (ai-log-analyzer / netlog-ai) with serve, analyze, containers, and mcp subcommands." },
     { name: "topology_infer.py", tech: "Python", resp: "Multi-signal edge inference (BGP, MLAG, descriptions, subnets) feeding the multi-layer topology graph builder (topology.py)." },
     { name: "site_optimize.py", tech: "Python", resp: "Site-wide cross-device gap finder emitting split scores: fabric_design_score and operational_readiness_score with ALLOWED_HOSTNAMES anchoring." }

--- a/src/ai_log_analyzer/classifier.py
+++ b/src/ai_log_analyzer/classifier.py
@@ -68,6 +68,7 @@ _KB_PATTERNS: list[tuple[str, str, str, str]] = [
     (r"chassisd|craft.*interface",                                      "low",      "hardware",   "Chassis daemon activity"),
     (r"rpd_isis|rpd_ospf|rpd.*(?:start|init|ready)",                    "low",      "routing",    "Routing daemon activity"),
     (r"pfed|dfwd|dcd",                                                  "low",      "system",     "Forwarding daemon activity"),
+    (r"inetd|xinetd|ftpd",                                              "low",      "system",     "inetd service activity"),
     (r"(?:arista|strata|eos).*(?:agent|process)",                       "low",      "system",     "EOS agent/process activity"),
     (r"jlaunchd|process.*(?:start|stop|restart)",                       "low",      "system",     "Process lifecycle event"),
     (r"last\s+message\s+repeated",                                      "low",      "system",     "Repeated message suppressed"),

--- a/src/ai_log_analyzer/correlate.py
+++ b/src/ai_log_analyzer/correlate.py
@@ -1,0 +1,224 @@
+"""Cross-source device correlation.
+
+Generalizes the DCN "device appears in Kibana AND LibreNMS" intersection
+(DCN_AI_Intelligence/app.py:1778-1815) to N netlog-ai sources. A device that
+surfaces actionable (>= medium) events from >=2 distinct sources is `confirmed`
+(corroborated by independent telemetry); a device seen in exactly 1 source is
+`suspected` (single-source, may be noise).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from ai_log_analyzer.classifier import LogEvent, classify_events
+
+# Severity rank used to pick a device's worst severity across sources.
+_SEV_RANK: dict[str, int] = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+
+
+def _short_host(hostname: str) -> str:
+    """Normalize a hostname to its short form (strip domain), lowercased."""
+    return (hostname or "").split(".")[0].strip().lower()
+
+
+def _site_of(hostname: str) -> str:
+    """Best-effort site/pod prefix, e.g. 'fra4-fw-01' -> 'fra4'. '' if no match."""
+    m = re.match(r"([a-z]{2,}\d+)", _short_host(hostname))
+    return m.group(1) if m else ""
+
+
+@dataclass
+class DeviceCorrelation:
+    """Per-device cross-source roll-up."""
+
+    hostname: str
+    site: str
+    sources: list[str]                  # distinct source ids the device appears in (sorted)
+    source_count: int
+    status: str                         # "confirmed" (>=2 sources) | "suspected" (1 source)
+    worst_severity: str                 # worst severity seen across all sources
+    total_events: int                   # actionable events across all sources
+    per_source_counts: dict[str, int]   # source_id -> actionable event count
+    categories: list[str]              # sorted distinct categories observed
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain-dict representation suitable for JSON serialisation."""
+        return {
+            "hostname": self.hostname,
+            "site": self.site,
+            "sources": self.sources,
+            "source_count": self.source_count,
+            "status": self.status,
+            "worst_severity": self.worst_severity,
+            "total_events": self.total_events,
+            "per_source_counts": self.per_source_counts,
+            "categories": self.categories,
+        }
+
+
+def correlate_sources(
+    events_by_source: dict[str, list[LogEvent]],
+    *,
+    min_severity: str = "medium",
+) -> dict[str, Any]:
+    """Correlate actionable devices across multiple sources.
+
+    ``events_by_source`` maps a source id to its raw LogEvents. Each source's
+    events are classified independently, devices are keyed by short hostname,
+    and a device is ``confirmed`` when it appears (with >= ``min_severity``
+    events) in >= 2 sources, else ``suspected``.
+
+    Returns an immutable result dict::
+
+        {
+          "ok": True,
+          "source_ids": [...],                 # sources actually seen
+          "device_count": int,
+          "confirmed_count": int,
+          "suspected_count": int,
+          "confirmed": [DeviceCorrelation.to_dict(), ...],   # sorted worst-first
+          "suspected": [DeviceCorrelation.to_dict(), ...],
+          "devices": [ ...all... ],            # confirmed + suspected, worst-first
+        }
+
+    Raises ``ValueError`` if *min_severity* is not a known severity label.
+    """
+    if min_severity not in _SEV_RANK:
+        raise ValueError(
+            f"Unknown min_severity {min_severity!r}. "
+            f"Valid values: {sorted(_SEV_RANK, key=_SEV_RANK.__getitem__)}"
+        )
+
+    min_rank: int = _SEV_RANK[min_severity]
+
+    # Accumulate per-device stats across sources.
+    # Key: short hostname.
+    # Value dict keys: "source_ids" (set), "per_source" (dict), "worst_rank" (int),
+    #                  "total" (int), "categories" (set).
+    device_acc: dict[str, dict[str, Any]] = {}
+
+    source_ids_seen: list[str] = sorted(events_by_source.keys())
+
+    for source_id, raw_events in events_by_source.items():
+        classified, _, _ = classify_events(raw_events)
+        # Filter down to actionable events only.
+        for ev in classified:
+            if _SEV_RANK.get(ev.severity, 999) > min_rank:
+                continue
+            host = _short_host(ev.hostname)
+            if not host:
+                continue
+            if host not in device_acc:
+                device_acc[host] = {
+                    "source_ids": set(),
+                    "per_source": {},
+                    "worst_rank": 999,
+                    "total": 0,
+                    "categories": set(),
+                }
+            acc = device_acc[host]
+            acc["source_ids"].add(source_id)
+            acc["per_source"][source_id] = acc["per_source"].get(source_id, 0) + 1
+            ev_rank = _SEV_RANK.get(ev.severity, 999)
+            if ev_rank < acc["worst_rank"]:
+                acc["worst_rank"] = ev_rank
+            acc["total"] += 1
+            acc["categories"].add(ev.category)
+
+    # Build DeviceCorrelation objects.
+    confirmed: list[DeviceCorrelation] = []
+    suspected: list[DeviceCorrelation] = []
+
+    # Reverse-map rank -> label.
+    _RANK_SEV: dict[int, str] = {v: k for k, v in _SEV_RANK.items()}
+
+    for host, acc in device_acc.items():
+        sources_list = sorted(acc["source_ids"])
+        source_count = len(sources_list)
+        status = "confirmed" if source_count >= 2 else "suspected"
+        worst_rank = acc["worst_rank"]
+        worst_sev = _RANK_SEV.get(worst_rank, "info")
+        dc = DeviceCorrelation(
+            hostname=host,
+            site=_site_of(host),
+            sources=sources_list,
+            source_count=source_count,
+            status=status,
+            worst_severity=worst_sev,
+            total_events=acc["total"],
+            per_source_counts=dict(acc["per_source"]),
+            categories=sorted(acc["categories"]),
+        )
+        if status == "confirmed":
+            confirmed.append(dc)
+        else:
+            suspected.append(dc)
+
+    def _sort_key(dc: DeviceCorrelation) -> tuple[int, int, str]:
+        return (_SEV_RANK.get(dc.worst_severity, 999), -dc.total_events, dc.hostname)
+
+    confirmed.sort(key=_sort_key)
+    suspected.sort(key=_sort_key)
+
+    all_devices: list[DeviceCorrelation] = confirmed + suspected
+
+    return {
+        "ok": True,
+        "source_ids": source_ids_seen,
+        "device_count": len(all_devices),
+        "confirmed_count": len(confirmed),
+        "suspected_count": len(suspected),
+        "confirmed": [dc.to_dict() for dc in confirmed],
+        "suspected": [dc.to_dict() for dc in suspected],
+        "devices": [dc.to_dict() for dc in all_devices],
+    }
+
+
+def correlate_from_manager(
+    source_ids: list[str] | None = None,
+    *,
+    since_seconds: int = 3600,
+    limit: int = 5000,
+    min_severity: str = "medium",
+) -> dict[str, Any]:
+    """Fetch from the live SourceManager singleton and correlate.
+
+    When ``source_ids`` is None, use all registered sources
+    (``source_manager.list_ids()``); an explicit empty list selects none.
+    Unknown or failing sources are skipped (their error captured under
+    ``"skipped"``); never raises for a single bad source.
+
+    Returns the ``correlate_sources(...)`` dict plus a
+    ``"skipped": {source_id: error_str}`` key.
+    """
+    # Deferred import avoids an import cycle at module load time.
+    from ai_log_analyzer.sources.manager import manager as source_manager
+    from ai_log_analyzer.sources.base import SourceError
+
+    # None => all registered sources; an explicit empty list => no sources.
+    ids: list[str] = (
+        source_manager.list_ids() if source_ids is None else list(source_ids)
+    )
+
+    events_by_source: dict[str, list[LogEvent]] = {}
+    skipped: dict[str, str] = {}
+
+    for sid in ids:
+        try:
+            events = source_manager.fetch(
+                sid,
+                since_seconds=since_seconds,
+                limit=limit,
+            )
+            events_by_source[sid] = events
+        except SourceError as exc:
+            skipped[sid] = str(exc)
+
+    # Build a new dict rather than mutating correlate_sources()'s result,
+    # whose contract is to return a fresh, self-contained dict.
+    return {
+        **correlate_sources(events_by_source, min_severity=min_severity),
+        "skipped": skipped,
+    }

--- a/src/ai_log_analyzer/device_triage.py
+++ b/src/ai_log_analyzer/device_triage.py
@@ -1,0 +1,272 @@
+"""Per-device deep triage.
+
+Ports DCN api_device_deep() (DCN_AI_Intelligence/app.py:2412) error-pattern
+normalization (strip hex addrs / IPs / PIDs, then frequency-dedup) and the
+verdict + health-score chain — re-targeted from Kibana hits to netlog-ai
+LogEvents for a single host.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from ai_log_analyzer.classifier import LogEvent
+
+# Raw-severity buckets considered error-grade for pattern dedup (DCN parity).
+_ERROR_SEVS: frozenset[str] = frozenset({"err", "error", "crit", "emerg", "alert"})
+
+# Normalization passes (order matters; DCN app.py:2501-2503).
+_HEX_RE: re.Pattern[str] = re.compile(r"\b0x[0-9a-fA-F]+\b")
+_PID_RE: re.Pattern[str] = re.compile(r"\[\d+\]")
+_IP_RE: re.Pattern[str]  = re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b")
+
+
+def normalize_pattern(message: str) -> str:
+    """Collapse a log message to a dedup key: 0x.. -> 0xADDR, [123] -> [N],
+    a.b.c.d -> IP, then truncate to 120 chars. (DCN app.py:2501-2504)."""
+    key = _HEX_RE.sub("0xADDR", message or "")
+    key = _PID_RE.sub("[N]", key)
+    key = _IP_RE.sub("IP", key)
+    return key[:120].strip()
+
+
+@dataclass
+class DevicePattern:
+    """Frequency-deduped error-pattern entry."""
+
+    pattern: str
+    count: int
+    severity: str       # raw severity of first occurrence
+    app: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain-dict representation."""
+        return {
+            "pattern": self.pattern,
+            "count": self.count,
+            "severity": self.severity,
+            "app": self.app,
+        }
+
+
+@dataclass
+class DeviceTriage:
+    """Full per-device triage result."""
+
+    hostname: str
+    total_events: int
+    severity_dist: dict[str, int]        # raw-severity histogram
+    processes: list[dict[str, Any]]      # [{process, count, pct}] desc by count
+    patterns: list[dict[str, Any]]       # top-20 deduped error patterns desc
+    verdict: str
+    issue_type: str                      # hardware|routing|lag|license|memory|security|general|info
+    health_score: int                    # 0-100
+    top_process: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain-dict representation suitable for JSON serialization."""
+        return {
+            "hostname": self.hostname,
+            "total_events": self.total_events,
+            "severity_dist": self.severity_dist,
+            "processes": self.processes,
+            "patterns": self.patterns,
+            "verdict": self.verdict,
+            "issue_type": self.issue_type,
+            "health_score": self.health_score,
+            "top_process": self.top_process,
+        }
+
+
+def triage_device(hostname: str, events: list[LogEvent]) -> DeviceTriage:
+    """Analyze one host's LogEvents into a triage verdict.
+
+    Uses ``ev.severity_raw`` for the DCN-style raw histogram + error dedup, and
+    ``ev.appname`` as the process. Pure: does not mutate ``events``. Empty input
+    yields verdict 'No events found', score 100, issue_type 'info'.
+    """
+    if not events:
+        return DeviceTriage(
+            hostname=hostname,
+            total_events=0,
+            severity_dist={},
+            processes=[],
+            patterns=[],
+            verdict="No events found",
+            issue_type="info",
+            health_score=100,
+            top_process="",
+        )
+
+    total = len(events)
+
+    # ── Raw severity histogram ───────────────────────────────────────────────
+    sev_dist: dict[str, int] = {}
+    for ev in events:
+        raw_sev = (ev.severity_raw or "").lower()
+        sev_dist[raw_sev] = sev_dist.get(raw_sev, 0) + 1
+
+    # ── Process breakdown ────────────────────────────────────────────────────
+    process_counts: dict[str, int] = {}
+    for ev in events:
+        proc = ev.appname or "unknown"
+        process_counts[proc] = process_counts.get(proc, 0) + 1
+
+    processes: list[dict[str, Any]] = sorted(
+        [
+            {
+                "process": k,
+                "count": v,
+                "pct": round(v / total * 100, 1),
+            }
+            for k, v in process_counts.items()
+        ],
+        key=lambda x: x["count"],
+        reverse=True,
+    )
+
+    top_process: str = processes[0]["process"] if processes else "unknown"
+
+    # ── Error pattern deduplication (DCN app.py:2496-2511) ──────────────────
+    pattern_acc: dict[str, dict[str, Any]] = {}
+    error_apps: set[str] = set()
+    for ev in events:
+        raw_sev = (ev.severity_raw or "").lower()
+        if raw_sev not in _ERROR_SEVS:
+            continue
+        error_apps.add(ev.appname or "unknown")
+        key = normalize_pattern(ev.message)
+        if not key:
+            continue
+        if key not in pattern_acc:
+            pattern_acc[key] = {
+                "pattern": key,
+                "count": 0,
+                "severity": raw_sev,
+                "app": ev.appname or "unknown",
+            }
+        pattern_acc[key]["count"] += 1
+
+    patterns: list[dict[str, Any]] = sorted(
+        pattern_acc.values(),
+        key=lambda x: x["count"],
+        reverse=True,
+    )[:20]
+
+    # ── Health score (DCN app.py:2524-2528) ─────────────────────────────────
+    crit_count = (
+        sev_dist.get("crit", 0)
+        + sev_dist.get("emerg", 0)
+        + sev_dist.get("alert", 0)
+    )
+    err_count = sev_dist.get("err", 0) + sev_dist.get("error", 0)
+    warn_count = sev_dist.get("warning", 0) + sev_dist.get("warn", 0)
+
+    score = 100
+    score -= min(crit_count * 5, 50)
+    score -= min(err_count // 100 * 5, 30)
+    score -= min(warn_count // 500 * 2, 10)
+    score = max(0, score)
+
+    # ── Verdict chain (DCN app.py:2530-2560) — evaluated in exact order ─────
+    top_pat: str = patterns[0]["pattern"].lower() if patterns else ""
+
+    if (
+        top_process in ("fpc0", "fpc1", "fpc2", "chassisd")
+        or "parity" in top_pat
+        or "sbus" in top_pat
+    ):
+        verdict = "HARDWARE FAILURE — FPC/ASIC Hardware Errors"
+        issue_type = "hardware"
+    elif top_process == "rpd" or "bgp" in top_pat:
+        verdict = "ROUTING ISSUE — BGP/Routing Protocol Errors"
+        issue_type = "routing"
+    elif "lacpd" in top_process or "lag" in top_pat or "lacp" in top_pat:
+        verdict = "LAG/LACP ISSUE — Link Aggregation Errors"
+        issue_type = "lag"
+    elif "license" in top_pat:
+        verdict = "LICENSE EXPIRATION — Feature License Issues"
+        issue_type = "license"
+    elif "swap" in top_pat or "memory" in top_pat:
+        verdict = "MEMORY EXHAUSTION — Kernel/Process Memory Issues"
+        issue_type = "memory"
+    elif top_process == "sshd" and "sshd" in error_apps:
+        verdict = "SSH ACTIVITY — Authentication / Session Events"
+        issue_type = "security"
+    elif crit_count > 100:
+        verdict = "CRITICAL ERRORS — Multiple High-Severity Events"
+        issue_type = "general"
+    elif err_count > 1000:
+        verdict = "HIGH ERROR RATE — Sustained Error Condition"
+        issue_type = "general"
+    else:
+        verdict = "INFORMATIONAL — No Critical Issues Detected"
+        issue_type = "info"
+
+    return DeviceTriage(
+        hostname=hostname,
+        total_events=total,
+        severity_dist=sev_dist,
+        processes=processes,
+        patterns=patterns,
+        verdict=verdict,
+        issue_type=issue_type,
+        health_score=score,
+        top_process=top_process,
+    )
+
+
+def triage_from_manager(
+    hostname: str,
+    source_ids: list[str] | None = None,
+    *,
+    since_seconds: int = 86_400,
+    limit: int = 5000,
+) -> dict[str, Any]:
+    """Fetch this host's events from one or more live sources and triage.
+
+    ``source_ids`` None => all registered sources; an explicit empty list
+    selects none. Failing sources are skipped (error captured under
+    ``"skipped"``; never raises for a single bad source). Returns::
+
+        {
+          "ok": True,
+          **DeviceTriage.to_dict(),
+          "sources": [...used...],
+          "skipped": {source_id: error_str},
+        }
+    """
+    # Deferred import avoids import cycle at module load time.
+    from ai_log_analyzer.sources.manager import manager as source_manager
+    from ai_log_analyzer.sources.base import SourceError
+
+    # None => all registered sources; an explicit empty list => no sources.
+    ids: list[str] = (
+        source_manager.list_ids() if source_ids is None else list(source_ids)
+    )
+
+    all_events: list[LogEvent] = []
+    used_sources: list[str] = []
+    skipped: dict[str, str] = {}
+
+    for sid in ids:
+        try:
+            events = source_manager.fetch(
+                sid,
+                since_seconds=since_seconds,
+                limit=limit,
+                host_filter=hostname,
+            )
+            all_events.extend(events)
+            used_sources.append(sid)
+        except SourceError as exc:
+            skipped[sid] = str(exc)
+
+    result_obj = triage_device(hostname, all_events)
+    return {
+        "ok": True,
+        **result_obj.to_dict(),
+        "sources": used_sources,
+        "skipped": skipped,
+    }

--- a/src/ai_log_analyzer/kb.py
+++ b/src/ai_log_analyzer/kb.py
@@ -28,11 +28,49 @@ from typing import Any
 _BGP_DOWN = {
     "match": r"bgp.*(?:down|connect|idle|notification|hold|cease)",
     "root_cause": (
-        "BGP session torn down — most commonly TCP/179 unreachability, "
-        "hold-timer expiration, peer reset, MD5 mismatch, or route-policy change."
+        "BGP session failure. Common causes: (1) Physical link down between peers, "
+        "(2) Underlay routing failure (no route to peer loopback), (3) TCP port 179 "
+        "blocked by firewall/ACL, (4) Peer device down or misconfigured, "
+        "(5) Hold timer expiry due to CPU overload."
     ),
     "risk": "Routes via this peer withdrawn → traffic blackhole or re-route through suboptimal path.",
     "timeline": "P1 — investigate within 15 min; service-impacting if uplink peer.",
+    "rca": {
+        "root_cause": (
+            "BGP session failure. Common causes: (1) Physical link down between peers, "
+            "(2) Underlay routing failure (no route to peer loopback), (3) TCP port 179 "
+            "blocked by firewall/ACL, (4) Peer device down or misconfigured, "
+            "(5) Hold timer expiry due to CPU overload."
+        ),
+        "risk": "Routes learned via failed peer are lost → traffic blackholing. If multiple peers fail, site may become isolated from IBGP mesh.",
+        "resolution_steps": [
+            "Check if BGP peer device is reachable (ping loopback)",
+            "Verify physical link status between devices",
+            "Check route table for path to peer address",
+            "Verify no firewall/ACL blocking TCP 179",
+            "Review BGP neighbor configuration on both sides",
+            "Check CPU/memory on both devices (hold timer expiry = CPU issue)",
+            "If IBGP: verify IGP (OSPF/ISIS) is healthy",
+        ],
+        "cli_junos": [
+            "show bgp summary",
+            "show bgp neighbor <peer-ip>",
+            "show route <peer-ip>",
+            "ping <peer-ip> source <local-loopback> rapid count 5",
+            "show ospf neighbor",
+            "show isis adjacency",
+            "show firewall filter __default_bpdu_filter__",
+            "show system processes extensive | match rpd",
+        ],
+        "cli_eos": [
+            "show bgp summary",
+            "show bgp neighbor <peer-ip>",
+            "show ip route <peer-ip>",
+            "ping <peer-ip> source <loopback>",
+            "show ip ospf neighbor",
+        ],
+        "timeline": "P1 — Verify reachability NOW. Fix routing/link within hours.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -150,6 +188,29 @@ _OSPF_ADJ = {
     ),
     "risk": "Intra-area routing recomputation; transient blackholes during SPF run.",
     "timeline": "P2 — investigate within 1h.",
+    "rca": {
+        "root_cause": "OSPF adjacency change. Neighbors going down indicates link failure, MTU mismatch, area misconfiguration, or dead timer expiry.",
+        "risk": "SPF recalculation, route convergence delay, potential traffic rerouting through suboptimal paths.",
+        "resolution_steps": [
+            "Check OSPF neighbor state and identify which neighbor changed",
+            "Verify physical link to the neighbor",
+            "Check MTU matches on both sides of the link",
+            "Verify OSPF area, hello/dead timers match",
+            "Review interface error counters for drops/CRC errors",
+        ],
+        "cli_junos": [
+            "show ospf neighbor",
+            "show ospf neighbor detail",
+            "show ospf interface",
+            "show interfaces <intf> extensive | match \"error|drop|MTU\"",
+        ],
+        "cli_eos": [
+            "show ip ospf neighbor",
+            "show ip ospf interface",
+            "show interfaces <intf> counters errors",
+        ],
+        "timeline": "P1 — Investigate immediately.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -245,6 +306,36 @@ _INT_DOWN = {
     ),
     "risk": "Traffic loss on this link; degraded LAG throughput if member; full outage if uplink.",
     "timeline": "P1 — immediate if uplink/transit.",
+    "rca": {
+        "root_cause": "Interface state change (link down/up or flapping). Common causes: (1) SFP/transceiver failure, (2) Fiber cut or bend, (3) Patch panel issue, (4) Auto-negotiation failure, (5) Remote device reboot, (6) Error-disable due to excessive errors.",
+        "risk": "Traffic disruption on affected interface, potential impact on LAG if member link, customer-facing outage if last-resort path.",
+        "resolution_steps": [
+            "Check interface status and error counters",
+            "Verify SFP Rx/Tx optical power (low Rx = fiber issue, low Tx = SFP issue)",
+            "Check for CRC, input, or output errors (indicates physical layer problem)",
+            "Verify auto-negotiation or speed/duplex settings",
+            "Check remote device interface status",
+            "If flapping: look for pattern (regular = auto-neg, random = fiber)",
+            "If error-disabled: identify trigger, fix root cause, re-enable",
+        ],
+        "cli_junos": [
+            "show interfaces <intf> extensive",
+            "show interfaces <intf> | match \"Physical|Status|Speed|Duplex\"",
+            "show interfaces diagnostics optics <intf>",
+            "show log messages | match <intf> | last 20",
+            "set interfaces <intf> disable",
+            "delete interfaces <intf> disable",
+            "commit",
+        ],
+        "cli_eos": [
+            "show interfaces <intf>",
+            "show interfaces <intf> counters errors",
+            "show interfaces <intf> transceiver detail",
+            "interface <intf>",
+            "  shutdown / no shutdown",
+        ],
+        "timeline": "P1 — Check SFP and cabling today.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -334,6 +425,33 @@ _LAG_DOWN = {
     ),
     "risk": "Reduced bundle throughput; full LAG-down if last member.",
     "timeline": "P1 if LAG-down; P2 if member-only.",
+    "rca": {
+        "root_cause": "LAG/LACP member link event. Possible causes: (1) Physical link failure (SFP, fiber, patch panel), (2) LACP mode mismatch (active vs passive), (3) LACP timeout mismatch, (4) Speed/duplex mismatch, (5) Remote side interface down.",
+        "risk": "Reduced aggregate bandwidth, potential traffic loss if minimum-links threshold is breached, hash redistribution causing microloops.",
+        "resolution_steps": [
+            "Identify which LAG member(s) are affected",
+            "Check physical layer — SFP Rx/Tx power, fiber integrity",
+            "Verify LACP mode matches on both ends (active/active or active/passive)",
+            "Check LACP timeout settings (fast vs slow)",
+            "Verify interface speed matches on both sides",
+            "Check for CRC errors or input/output errors on member interfaces",
+            "Test with alternative SFP/fiber if available",
+        ],
+        "cli_junos": [
+            "show lacp interfaces",
+            "show lacp statistics interfaces ae<N>",
+            "show interfaces ae<N> detail",
+            "show interfaces ae<N> | match \"Physical|Status|Speed\"",
+            "show interfaces diagnostics optics <member-intf>",
+        ],
+        "cli_eos": [
+            "show lacp neighbor",
+            "show lacp counters",
+            "show port-channel <N> detailed",
+            "show interfaces <member> transceiver detail",
+        ],
+        "timeline": "P1 — Check physical cabling NOW. Replace SFP if needed.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -420,6 +538,33 @@ _ASIC_PARITY = {
     ),
     "risk": "Forwarding-table corruption — packet drops or unicast blackholing through the affected hash bucket.",
     "timeline": "P1 — schedule FPC restart in maintenance window; RMA if recurring.",
+    "rca": {
+        "root_cause": "Permanent (hard) parity error in switching ASIC SRAM. The SER (Soft Error Recovery) mechanism repeatedly fails to correct the error at a fixed memory address, indicating physical silicon damage — not a transient cosmic ray bit flip.",
+        "risk": "IPv4/IPv6 traffic blackholing through affected hash bucket, incorrect forwarding decisions, sustained CPU overhead from error logging, syslog flooding consuming disk/bandwidth.",
+        "resolution_steps": [
+            "Verify error is at fixed address (same address every time = hard error)",
+            "Check current memory status and identify affected forwarding table",
+            "Attempt FPC restart in maintenance window to clear SRAM",
+            "If error persists after restart → hardware RMA required",
+            "Check if other devices of same model/site show similar errors (systemic issue)",
+        ],
+        "cli_junos": [
+            "show chassis hardware | match FPC",
+            "show chassis alarms",
+            "show system memory",
+            "show pfe statistics traffic",
+            "request pfe execute target fpc0 command \"show memory\"",
+            "show system core-dumps",
+            "request chassis fpc slot 0 restart",
+            "request support information | save /var/tmp/techsupport.txt",
+        ],
+        "cli_eos": [
+            "show platform sand memory-usage",
+            "show hardware tcam profile | no-more",
+            "show logging last 100 | grep -i parity",
+        ],
+        "timeline": "P1 — Reboot FPC this week. If persists, RMA ASAP.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -509,6 +654,32 @@ _LICENSE = {
     "root_cause": "Feature license expiration / invalid — affects BGP, EVPN, VXLAN, VC, etc.",
     "risk": "Feature degradation — sessions may drop, fabric disruption, compliance audit finding.",
     "timeline": "P1 if expired today; P2 if expiring within 30 days.",
+    "rca": {
+        "root_cause": "Juniper feature license expiration. When licenses expire, features like BGP, EVPN, VXLAN, Virtual Chassis, and advanced routing may stop working or operate in degraded mode.",
+        "risk": "Feature degradation or complete loss. BGP license expiry → sessions may drop. VXLAN license expiry → EVPN fabric disruption. VC license → virtual chassis split.",
+        "resolution_steps": [
+            "Identify which licenses have expired and which features are affected",
+            "Check if expired licenses are actively used by running features",
+            "Contact Juniper licensing team for renewal",
+            "Apply new license keys via CLI",
+            "Verify features are operational after license renewal",
+            "Audit all devices for upcoming license expirations",
+        ],
+        "cli_junos": [
+            "show system license",
+            "show system license usage",
+            "show system license keys",
+            "request system license add <license-key>",
+            "show bgp summary",
+            "show evpn database | count",
+            "show virtual-chassis status",
+        ],
+        "cli_eos": [
+            "show license",
+            "show license status",
+        ],
+        "timeline": "P1 — Renew licenses TODAY before feature degradation.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -575,6 +746,30 @@ _AUTH_FAIL = {
     "root_cause": "Management auth failure — brute force, misconfigured client, or credential rotation.",
     "risk": "Unauthorized access attempt or service disruption from automated tools.",
     "timeline": "P1 if many failures from one IP; P3 for isolated events.",
+    "rca": {
+        "root_cause": "Security event — authentication failure, ACL deny, or IDS alert. Could indicate: (1) Brute force SSH attempt, (2) Misconfigured credentials, (3) Unauthorized access attempt, (4) ACL blocking legitimate traffic.",
+        "risk": "If brute force: potential unauthorized access. If ACL deny: legitimate traffic may be blocked. If IDS: possible intrusion attempt.",
+        "resolution_steps": [
+            "Review failed login source IPs — are they known/authorized?",
+            "Check if failures are from automation (scripts with old credentials)",
+            "Verify SSH access-list configuration",
+            "Check for patterns (same source = brute force, random = scan)",
+            "Tighten firewall filters if unauthorized sources detected",
+            "Enable rate-limiting on SSH if not already configured",
+        ],
+        "cli_junos": [
+            "show log messages | match \"sshd|login|auth\" | last 50",
+            "show system login",
+            "show firewall filter <ssh-filter> detail",
+            "show system connections | match :22",
+        ],
+        "cli_eos": [
+            "show logging last 50 | grep -i auth",
+            "show users",
+            "show ip access-lists",
+        ],
+        "timeline": "P2 — Review auth logs today, tighten access if needed.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -651,6 +846,33 @@ _KERNEL_PANIC = {
     "root_cause": "OS-level failure — kernel panic, OOM kill, or core dump. Possible memory leak, hardware fault, or corrupted firmware.",
     "risk": "Device reboot, control-plane outage, possible data-plane impact during recovery.",
     "timeline": "P1 — collect evidence immediately, before next reboot loses it.",
+    "rca": {
+        "root_cause": "System-level error — kernel panic, memory exhaustion, or process crash. Often caused by software bug, memory leak, or resource exhaustion under load.",
+        "risk": "Device instability, potential routing engine failover, process restart, or complete device crash.",
+        "resolution_steps": [
+            "Check system memory and process status",
+            "Look for core dumps that indicate crashed processes",
+            "Check system uptime (very long uptime + memory issue = likely leak)",
+            "Schedule maintenance reboot if memory is critically low",
+            "Check for known Junos/EOS bugs matching the error pattern",
+            "Upgrade to latest maintenance release if bug is identified",
+        ],
+        "cli_junos": [
+            "show system memory",
+            "show system processes extensive | match \"PID|mem|rpd|fpc\"",
+            "show system core-dumps",
+            "show system uptime",
+            "show version",
+            "request system core-dumps delete",
+            "request system reboot at <time> message \"Memory maintenance\"",
+        ],
+        "cli_eos": [
+            "show processes top once",
+            "show version | grep memory",
+            "show uptime",
+        ],
+        "timeline": "P1 — Check memory NOW. Schedule reboot if critical.",
+    },
     "phases": [
         {
             "name": "Diagnose",
@@ -723,6 +945,511 @@ _KERNEL_PANIC = {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# VPN / IPsec tunnel failure  (DCN _AI_KB "vpn" category port)
+# ─────────────────────────────────────────────────────────────────────────────
+_VPN_DOWN = {
+    "match": r"ike|ipsec|vpn|tunnel",
+    "root_cause": (
+        "VPN/IPsec tunnel failure. Possible causes: (1) IKE Phase 1 mismatch (pre-shared key, "
+        "encryption algorithm, lifetime), (2) IKE Phase 2 mismatch (transform set, PFS group), "
+        "(3) NAT interference, (4) Firewall blocking UDP 500/4500, (5) Certificate expiry, "
+        "(6) Peer device down."
+    ),
+    "risk": "Site-to-site connectivity loss. Remote site may be completely isolated if VPN is the only path.",
+    "timeline": "P1 — Verify VPN peer reachability and IKE config NOW.",
+    "rca": {
+        "root_cause": "VPN/IPsec tunnel failure. Possible causes: (1) IKE Phase 1 mismatch (pre-shared key, encryption algorithm, lifetime), (2) IKE Phase 2 mismatch (transform set, PFS group), (3) NAT interference, (4) Firewall blocking UDP 500/4500, (5) Certificate expiry, (6) Peer device down.",
+        "risk": "Site-to-site connectivity loss. Remote site may be completely isolated if VPN is the only path.",
+        "resolution_steps": [
+            "Check IKE SA (Phase 1) status — is it established?",
+            "Check IPsec SA (Phase 2) status — are there active SAs?",
+            "Verify pre-shared key matches on both sides",
+            "Check IKE proposals match (encryption, hash, DH group, lifetime)",
+            "Verify no NAT between peers (or NAT-T is enabled)",
+            "Check firewall rules allow UDP 500, 4500, and ESP (protocol 50)",
+            "If certificate-based: check certificate expiry dates",
+        ],
+        "cli_junos": [
+            "show security ike security-associations",
+            "show security ipsec security-associations",
+            "show security ike security-associations detail",
+            "show security ipsec statistics",
+            "show log kmd | last 20",
+        ],
+        "cli_eos": [
+            "show ip security connection",
+            "show ip security policy",
+        ],
+        "timeline": "P1 — Verify VPN peer reachability and IKE config NOW.",
+    },
+    "phases": [
+        {
+            "name": "Diagnose",
+            "goal": "Check IKE/IPsec SA status and identify the phase that failed.",
+            "actions": [
+                {"cli": {"junos": "show security ike security-associations",
+                         "eos": "show ip security connection"},
+                 "expected": "IKE Phase 1 SA established; State = UP",
+                 "note": "Missing IKE SA = Phase 1 failure (pre-shared key, proposal mismatch)"},
+                {"cli": {"junos": "show security ipsec security-associations",
+                         "eos": "show ip security policy"},
+                 "expected": "IPsec Phase 2 SAs active, bytes-in/out incrementing",
+                 "note": "IKE up but no IPsec SA = Phase 2 failure (transform set, PFS mismatch)"},
+                {"cli": {"junos": "show security ike security-associations detail",
+                         "eos": "show ip security connection detail"},
+                 "expected": "Detailed peer info including proposals and lifetime",
+                 "note": "Compare both sides — mismatch is the most common cause"},
+                {"cli": {"junos": "ping <peer-gateway-ip> rapid count 5",
+                         "eos": "ping <peer-gateway-ip>"},
+                 "expected": "0% loss — L3 path to peer is reachable",
+                 "note": "If 100% loss, routing/physical problem must be resolved first"},
+            ],
+        },
+        {
+            "name": "Mitigate",
+            "goal": "Bounce the tunnel to force re-negotiation.",
+            "actions": [
+                {"cli": {"junos": "clear security ike security-associations",
+                         "eos": "clear ip security association"},
+                 "expected": "IKE SAs cleared — device will re-initiate",
+                 "note": "Clears all SAs; use specific peer if in a hub config"},
+                {"cli": {"junos": "clear security ipsec security-associations"},
+                 "expected": "IPsec SAs cleared",
+                 "note": "Forces Phase 2 renegotiation"},
+            ],
+        },
+        {
+            "name": "Remediate",
+            "goal": "Fix proposal mismatch, expired certificates, or firewall blocks.",
+            "actions": [
+                {"cli": {"junos": "show configuration security ike",
+                         "eos": "show running-config | section crypto"},
+                 "expected": "Proposals, pre-shared key, gateway config",
+                 "note": "Must match peer-side exactly — encryption, hash, DH group, lifetime"},
+                {"cli": {"junos": "show log kmd | last 50"},
+                 "expected": "KMD log shows specific mismatch reason",
+                 "note": "Key messages: 'No proposal chosen', 'Invalid cookie'"},
+            ],
+        },
+        {
+            "name": "Verify",
+            "goal": "Tunnel up, traffic flowing.",
+            "actions": [
+                {"cli": {"junos": "show security ipsec security-associations",
+                         "eos": "show ip security connection"},
+                 "expected": "Active SAs with incrementing bytes-in/out",
+                 "note": ""},
+                {"cli": {"junos": "ping <remote-site-host> routing-instance <vpn-ri>",
+                         "eos": "ping <remote-site-host> source <local-int>"},
+                 "expected": "Traffic passes through the tunnel",
+                 "note": ""},
+            ],
+        },
+        {
+            "name": "Optimize",
+            "goal": "Reduce re-key downtime and improve resilience.",
+            "actions": [
+                {"cli": {"junos": "set security ike policy <policy> proposal-set standard"},
+                 "expected": "Standardized proposal set — fewer mismatch scenarios",
+                 "note": "Agree on a single proposal set across all peers"},
+                {"cli": {"junos": "set security ipsec vpn <vpn> establish-tunnels immediately"},
+                 "expected": "Tunnel pre-established rather than on-demand",
+                 "note": "Eliminates first-packet delay for new flows"},
+            ],
+        },
+    ],
+    "preventive_config": [
+        "# Junos — pre-established tunnel with standard proposals",
+        "  set security ipsec vpn <vpn> establish-tunnels immediately",
+        "  set security ike policy <p> proposal-set standard",
+        "  set security ike policy <p> pre-shared-key ascii-text <key>",
+    ],
+    "monitoring": [
+        "Alert if IPsec SA byte-counters don't increment for > 5 min on active tunnel",
+        "Alert on IKE negotiation failures",
+        "Track certificate expiry for cert-based peers — alert 30 days before",
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Gateway redundancy — VRRP/HSRP failover  (DCN _AI_KB "redundancy" port)
+# ─────────────────────────────────────────────────────────────────────────────
+_REDUNDANCY = {
+    "match": r"vrrp|hsrp|failover|master.*change",
+    "root_cause": (
+        "Gateway redundancy failover event (VRRP/HSRP). The master/primary gateway changed, "
+        "causing a brief traffic disruption. Common triggers: interface failure, device reboot, "
+        "priority change, or preemption."
+    ),
+    "risk": "Brief traffic disruption during failover (1–3 seconds typically). If failover is flapping, sustained disruption possible.",
+    "timeline": "P2 — Verify failover reason. Ensure original master recovers.",
+    "rca": {
+        "root_cause": "Gateway redundancy failover event (VRRP/HSRP). The master/primary gateway changed, causing a brief traffic disruption. Common triggers: interface failure, device reboot, priority change, or preemption.",
+        "risk": "Brief traffic disruption during failover (1-3 seconds typically). If failover is flapping, sustained disruption possible.",
+        "resolution_steps": [
+            "Identify which VRRP/HSRP group changed and which device is now master",
+            "Check if the original master is still alive",
+            "Verify VRRP priority and preemption settings",
+            "Check tracked interfaces/objects that may have triggered failover",
+            "Verify both devices agree on virtual IP and group configuration",
+        ],
+        "cli_junos": [
+            "show vrrp summary",
+            "show vrrp detail",
+            "show vrrp track-summary",
+        ],
+        "cli_eos": [
+            "show vrrp",
+            "show vrrp detail",
+        ],
+        "timeline": "P2 — Verify failover reason. Ensure original master recovers.",
+    },
+    "phases": [
+        {
+            "name": "Diagnose",
+            "goal": "Determine which VRRP/HSRP group failed over and why.",
+            "actions": [
+                {"cli": {"junos": "show vrrp summary",
+                         "eos": "show vrrp"},
+                 "expected": "Current master for each group; priority values",
+                 "note": "Check if failover matches expected priority ordering"},
+                {"cli": {"junos": "show vrrp detail",
+                         "eos": "show vrrp detail"},
+                 "expected": "Tracked object status, preemption settings, advertisement interval",
+                 "note": "Tracked interface down = expected failover; unexpected = config issue"},
+                {"cli": {"junos": "show vrrp track-summary"},
+                 "expected": "All tracked objects UP",
+                 "note": "Tracked object DOWN lowers priority below backup → triggers failover"},
+                {"cli": {"junos": "show log messages | match vrrp | last 20",
+                         "eos": "show logging | grep -i vrrp"},
+                 "expected": "State change log with timestamp and old/new master",
+                 "note": ""},
+            ],
+        },
+        {
+            "name": "Mitigate",
+            "goal": "Ensure one active master is forwarding traffic.",
+            "actions": [
+                {"cli": {"junos": "show vrrp summary",
+                         "eos": "show vrrp"},
+                 "expected": "Exactly one master per group",
+                 "note": "Two masters = split-brain; investigate immediately"},
+            ],
+        },
+        {
+            "name": "Remediate",
+            "goal": "Restore original master if desired, fix tracked object issue.",
+            "actions": [
+                {"cli": {"junos": "show configuration interfaces <int> family inet address vrrp-group",
+                         "eos": "show running-config | section vrrp"},
+                 "expected": "Priority and preemption settings correct on both devices",
+                 "note": "Priority should be higher on preferred master"},
+                {"cli": {"junos": "show interfaces <tracked-int> terse",
+                         "eos": "show interfaces <tracked-int> status"},
+                 "expected": "Tracked interface UP",
+                 "note": "If tracked interface is down, fix it to restore original master (if preemption is on)"},
+            ],
+        },
+        {
+            "name": "Verify",
+            "goal": "Correct master active, no split-brain, traffic flowing.",
+            "actions": [
+                {"cli": {"junos": "show vrrp summary",
+                         "eos": "show vrrp"},
+                 "expected": "Master is the intended device, all groups healthy",
+                 "note": ""},
+                {"cli": {"junos": "ping <virtual-ip> rapid count 5",
+                         "eos": "ping <virtual-ip>"},
+                 "expected": "Virtual IP responds",
+                 "note": ""},
+            ],
+        },
+        {
+            "name": "Optimize",
+            "goal": "Minimize failover time and prevent spurious failovers.",
+            "actions": [
+                {"cli": {"junos": "set interfaces <int> family inet address <vip>/24 vrrp-group <n> fast-interval 200"},
+                 "expected": "200ms advertisement interval instead of 1s",
+                 "note": "Reduces failover detection from 3s to <1s"},
+                {"cli": {"junos": "set interfaces <int> family inet address <vip>/24 vrrp-group <n> track interface <uplink> priority-cost 50"},
+                 "expected": "Priority drops by 50 when uplink goes down → automatic failover",
+                 "note": ""},
+            ],
+        },
+    ],
+    "preventive_config": [
+        "# Junos VRRP with fast timers + uplink tracking",
+        "  set interfaces <int> family inet address <vip>/24 vrrp-group <n> priority 110",
+        "  set interfaces <int> family inet address <vip>/24 vrrp-group <n> fast-interval 200",
+        "  set interfaces <int> family inet address <vip>/24 vrrp-group <n> preempt hold-time 5",
+        "  set interfaces <int> family inet address <vip>/24 vrrp-group <n> track interface <uplink> priority-cost 50",
+    ],
+    "monitoring": [
+        "Alert on any VRRP state change",
+        "Alert if VRRP group has no master for > 5s",
+        "Track VRRP failover frequency — alert if > 2/hour",
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FPC / line card error  (DCN _AI_KB "hardware.fpc" sub-entry port)
+# ─────────────────────────────────────────────────────────────────────────────
+_FPC_ERR = {
+    "match": r"fpc.*(?:offline|crash|error|halt|restart)|line.?card",
+    "root_cause": (
+        "FPC (Flexible PIC Concentrator) or line card experiencing errors. This could be caused by "
+        "hardware failure, memory exhaustion, software bug, or environmental factors (temperature, power)."
+    ),
+    "risk": "Forwarding plane disruption — traffic through affected FPC will be dropped. If device has redundant FPCs, traffic may reroute; if single FPC, full outage.",
+    "timeline": "P1 — Investigate immediately. RMA if hardware failure confirmed.",
+    "rca": {
+        "root_cause": "FPC (Flexible PIC Concentrator) or line card experiencing errors. This could be caused by hardware failure, memory exhaustion, software bug, or environmental factors (temperature, power).",
+        "risk": "Forwarding plane disruption — traffic through affected FPC will be dropped. If device has redundant FPCs, traffic may reroute; if single FPC, full outage.",
+        "resolution_steps": [
+            "Check FPC status and identify which FPC is affected",
+            "Review chassis alarms and environmental sensors",
+            "Check if FPC errors correlate with specific traffic patterns",
+            "Attempt FPC restart in maintenance window",
+            "Collect tech-support for vendor (JTAC) analysis",
+            "If hardware failure confirmed → initiate RMA",
+        ],
+        "cli_junos": [
+            "show chassis fpc",
+            "show chassis fpc detail",
+            "show chassis alarms",
+            "show chassis environment",
+            "show system alarms",
+            "show log messages | match fpc | last 50",
+            "request chassis fpc slot <N> restart",
+            "request support information | save /var/tmp/techsupport.txt",
+        ],
+        "cli_eos": [
+            "show module",
+            "show environment all",
+            "show logging last 100 | grep -i fpc",
+        ],
+        "timeline": "P1 — Investigate immediately. RMA if hardware failure confirmed.",
+    },
+    "phases": [
+        {
+            "name": "Diagnose",
+            "goal": "Identify which FPC/line-card is affected and the error type.",
+            "actions": [
+                {"cli": {"junos": "show chassis fpc",
+                         "eos": "show module"},
+                 "expected": "FPC state: Online / Offline / Error; memory usage",
+                 "note": "Offline or Error state = forwarding plane disrupted on this FPC"},
+                {"cli": {"junos": "show chassis fpc detail",
+                         "eos": "show environment all"},
+                 "expected": "Detailed status including temperature, CPU, memory per FPC",
+                 "note": "High CPU or memory = possible software bug or traffic storm"},
+                {"cli": {"junos": "show chassis alarms",
+                         "eos": "show module detail"},
+                 "expected": "Critical alarms for the affected FPC",
+                 "note": ""},
+                {"cli": {"junos": "show log messages | match fpc | last 50",
+                         "eos": "show logging last 100 | grep -i fpc"},
+                 "expected": "FPC error messages with timestamps",
+                 "note": "Repeated offline/online cycles = hardware instability"},
+            ],
+        },
+        {
+            "name": "Mitigate",
+            "goal": "Move traffic off the affected FPC to restore service.",
+            "actions": [
+                {"cli": {"junos": "show chassis fpc pic-status"},
+                 "expected": "Identify all PICs on the affected FPC and connected ports",
+                 "note": "Coordinate with peer to drain ports before restart"},
+                {"cli": {"junos": "request chassis fpc slot <N> offline",
+                         "eos": "shutdown module <N>"},
+                 "expected": "FPC gracefully offlined — traffic migrates via redundant paths",
+                 "note": "Only if redundant FPCs or ECMP paths exist"},
+            ],
+        },
+        {
+            "name": "Remediate",
+            "goal": "Restart FPC or initiate RMA.",
+            "actions": [
+                {"cli": {"junos": "request chassis fpc slot <N> restart",
+                         "eos": "reload module <N>"},
+                 "expected": "FPC reboots and comes back online",
+                 "note": "DISRUPTIVE — affects all ports on this FPC"},
+                {"cli": {"junos": "request support information | save /var/tmp/techsupport.txt",
+                         "eos": "show tech-support | save flash:tech.log"},
+                 "expected": "Evidence bundle for vendor RMA / JTAC case",
+                 "note": "Collect before restart if possible"},
+            ],
+        },
+        {
+            "name": "Verify",
+            "goal": "FPC back online, traffic forwarding correctly.",
+            "actions": [
+                {"cli": {"junos": "show chassis fpc",
+                         "eos": "show module"},
+                 "expected": "FPC state = Online, memory usage normal",
+                 "note": ""},
+                {"cli": {"junos": "show chassis alarms",
+                         "eos": "show environment all"},
+                 "expected": "No active alarms on this FPC",
+                 "note": ""},
+            ],
+        },
+        {
+            "name": "Optimize",
+            "goal": "Auto-restart on FPC failure, monitoring.",
+            "actions": [
+                {"cli": {"junos": "set chassis fpc <N> lite-mode"},
+                 "expected": "Reduced feature set on FPC — lower memory pressure",
+                 "note": "Only if FPC exhausting memory under normal load"},
+                {"cli": {"junos": "set system syslog file fpc-errors any any match fpc"},
+                 "expected": "Dedicated FPC error log for easier tracking",
+                 "note": ""},
+            ],
+        },
+    ],
+    "preventive_config": [
+        "# Dedicated FPC error log (Junos)",
+        "  set system syslog file fpc-errors any any",
+        "  set system syslog file fpc-errors match fpc",
+        "# Event policy — auto-collect tech-support on FPC offline",
+        "  set event-options policy fpc-offline-collect events CHASSISD_FPC_OFFLINE",
+        "  set event-options policy fpc-offline-collect then execute-commands ...",
+    ],
+    "monitoring": [
+        "Alert on any FPC offline/error event",
+        "Track FPC restarts per week — RMA threshold if > 2",
+        "Alert on FPC memory usage > 80%",
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Chassis environmental alarm  (DCN _AI_KB "hardware.chassis" sub-entry port)
+# ─────────────────────────────────────────────────────────────────────────────
+_CHASSIS_ENV = {
+    "match": r"chassis.*alarm|power.*fail|fan.*fail|psu|temperature",
+    "root_cause": (
+        "Chassis environmental alarm — power supply failure, fan failure, or temperature threshold exceeded. "
+        "These are hardware-level alerts that require physical intervention."
+    ),
+    "risk": "Reduced redundancy (single PSU/fan), potential thermal shutdown if temperature critical, device instability under load.",
+    "timeline": "P1 — Check within hours. Replace failed component ASAP.",
+    "rca": {
+        "root_cause": "Chassis environmental alarm — power supply failure, fan failure, or temperature threshold exceeded. These are hardware-level alerts that require physical intervention.",
+        "risk": "Reduced redundancy (single PSU/fan), potential thermal shutdown if temperature critical, device instability under load.",
+        "resolution_steps": [
+            "Identify which component triggered the alarm (PSU, fan, temp sensor)",
+            "Check environmental status for current readings",
+            "If PSU: verify power feed, check for loose connections",
+            "If Fan: check for obstruction, verify airflow path",
+            "If Temperature: check ambient temp, verify cooling, reduce load",
+            "Replace failed component — engage DC hands for physical access",
+        ],
+        "cli_junos": [
+            "show chassis alarms",
+            "show chassis environment",
+            "show chassis power",
+            "show chassis fan",
+            "show chassis temperature-thresholds",
+        ],
+        "cli_eos": [
+            "show environment all",
+            "show environment power",
+            "show environment cooling",
+            "show environment temperature",
+        ],
+        "timeline": "P1 — Check within hours. Replace failed component ASAP.",
+    },
+    "phases": [
+        {
+            "name": "Diagnose",
+            "goal": "Identify the failing component (PSU, fan, or thermal sensor).",
+            "actions": [
+                {"cli": {"junos": "show chassis alarms",
+                         "eos": "show environment all"},
+                 "expected": "Active alarms with component name (PEM 0, Fan 1, etc.)",
+                 "note": ""},
+                {"cli": {"junos": "show chassis environment",
+                         "eos": "show environment power"},
+                 "expected": "Temperature readings, PSU status (OK/Absent/Failed), fan speeds",
+                 "note": "Temperature > threshold = cooling failure; check ambient DC temp"},
+                {"cli": {"junos": "show chassis power",
+                         "eos": "show environment cooling"},
+                 "expected": "PSU input/output voltage, capacity",
+                 "note": "Both PSUs should be present and drawing power"},
+                {"cli": {"junos": "show chassis fan",
+                         "eos": "show environment temperature"},
+                 "expected": "All fans Running at normal RPM",
+                 "note": "Fan speed > 80% = thermal pressure; check airflow obstructions"},
+            ],
+        },
+        {
+            "name": "Mitigate",
+            "goal": "Reduce thermal load and prevent shutdown.",
+            "actions": [
+                {"cli": {"junos": "show chassis temperature-thresholds"},
+                 "expected": "Current temp vs thresholds — how close to shutdown?",
+                 "note": "If approaching threshold: reduce traffic load, improve airflow"},
+                {"cli": {"junos": "request chassis fpc slot <N> offline"},
+                 "expected": "Reduces power draw on affected FPC — lowers thermal load",
+                 "note": "Last resort — only if thermal shutdown is imminent"},
+            ],
+        },
+        {
+            "name": "Remediate",
+            "goal": "Replace failed hardware component (hands-on required).",
+            "actions": [
+                {"cli": {"junos": "show chassis hardware detail | match PEM",
+                         "eos": "show environment power detail"},
+                 "expected": "Part number and serial for replacement order",
+                 "note": "PSU hot-swappable on most platforms; fan tray usually too"},
+                {"cli": {"junos": "request support information | save /var/tmp/chassis-env.txt"},
+                 "expected": "Environmental snapshot for JTAC if under support contract",
+                 "note": ""},
+            ],
+        },
+        {
+            "name": "Verify",
+            "goal": "All alarms cleared, temperatures normal.",
+            "actions": [
+                {"cli": {"junos": "show chassis alarms",
+                         "eos": "show environment all"},
+                 "expected": "No active environmental alarms",
+                 "note": ""},
+                {"cli": {"junos": "show chassis environment",
+                         "eos": "show environment temperature"},
+                 "expected": "All temperatures below OK threshold",
+                 "note": ""},
+            ],
+        },
+        {
+            "name": "Optimize",
+            "goal": "Proactive thermal and power monitoring.",
+            "actions": [
+                {"cli": {"junos": "set chassis temperature-thresholds yellow-alarm <temp>"},
+                 "expected": "Early warning before red (shutdown) alarm",
+                 "note": "Set yellow ~10°C below red threshold"},
+                {"cli": {"junos": "set system syslog file chassis-env any any match chassis"},
+                 "expected": "Dedicated chassis event log",
+                 "note": ""},
+            ],
+        },
+    ],
+    "preventive_config": [
+        "# Yellow thermal alarm (early warning)",
+        "  set chassis temperature-thresholds yellow-alarm 55",
+        "# Chassis event log",
+        "  set system syslog file chassis-env any any",
+        "  set system syslog file chassis-env match chassis",
+    ],
+    "monitoring": [
+        "Alert on any PSU failure or absence (zero tolerance)",
+        "Alert when temperature > yellow threshold",
+        "Track fan RPM — alert if any fan stops",
+        "Alert if fewer PSUs present than expected",
+    ],
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # NTP sync lost
 # ─────────────────────────────────────────────────────────────────────────────
 _NTP_LOST = {
@@ -791,11 +1518,18 @@ KB: dict[str, dict[str, dict[str, Any]]] = {
     },
     "interface":  {"link_down":   _INT_DOWN,    "_default": _INT_DOWN},
     "lag":        {"_default":    _LAG_DOWN},
-    "hardware":   {"asic_parity": _ASIC_PARITY, "_default": _ASIC_PARITY},
+    "hardware": {
+        "parity":  _ASIC_PARITY,
+        "fpc":     _FPC_ERR,
+        "chassis": _CHASSIS_ENV,
+        "_default": _ASIC_PARITY,
+    },
     "compliance": {"license":     _LICENSE,     "_default": _LICENSE},
     "security":   {"auth_fail":   _AUTH_FAIL,   "_default": _AUTH_FAIL},
     "system":     {"_default":    _KERNEL_PANIC},
     "ntp":        {"_default":    _NTP_LOST},
+    "vpn":        {"tunnel_down": _VPN_DOWN,    "_default": _VPN_DOWN},
+    "redundancy": {"failover":    _REDUNDANCY,  "_default": _REDUNDANCY},
 }
 
 

--- a/src/ai_log_analyzer/mcp_server/server.py
+++ b/src/ai_log_analyzer/mcp_server/server.py
@@ -12,6 +12,8 @@ Tools exposed:
   - search_logs           : pull events filtered by a regex pattern
   - analyze_logs          : pull + classify + dedup + (optional) LLM ranking
   - get_top_offenders     : pull + return the N noisiest hostnames
+  - correlate_sources     : cross-source device correlation (confirmed/suspected)
+  - analyze_device        : per-device deep triage (verdict, score, process/pattern breakdown)
   - list_sites            : enumerate site bundles available locally
   - analyze_site          : run full site-wide analysis on a bundle
 
@@ -201,6 +203,49 @@ def _build_server():
         counter: Counter[str] = Counter(e.hostname or "unknown" for e in events)
         offenders = [{"hostname": h, "count": n} for h, n in counter.most_common(top_n)]
         return {"ok": True, "total_events": len(events), "offenders": offenders}
+
+    # ── cross-source correlation ─────────────────────────────────────────────
+    @mcp.tool()
+    def correlate_sources(
+        source_ids: list[str] | None = None,
+        since_seconds: int = 3600,
+        limit: int = 5000,
+        min_severity: str = "medium",
+    ) -> dict[str, Any]:
+        """Cross-source correlation: classify each source's events, then mark
+        every device `confirmed` (appears with actionable events in >=2 sources)
+        or `suspected` (1 source). Defaults to ALL registered sources."""
+        from ai_log_analyzer.correlate import correlate_from_manager
+        try:
+            return correlate_from_manager(
+                source_ids,
+                since_seconds=since_seconds,
+                limit=limit,
+                min_severity=min_severity,
+            )
+        except Exception as exc:  # noqa: BLE001 - never crash the MCP session
+            return {"ok": False, "error": str(exc)}
+
+    # ── per-device triage ────────────────────────────────────────────────────
+    @mcp.tool()
+    def analyze_device(
+        hostname: str,
+        source_ids: list[str] | None = None,
+        since_seconds: int = 86_400,
+        limit: int = 5000,
+    ) -> dict[str, Any]:
+        """Per-device deep triage: severity histogram, process breakdown,
+        frequency-deduped error patterns, a verdict (HARDWARE/ROUTING/LAG/...)
+        and a 0-100 health score. Pulls this host's events from the given
+        sources (default: all registered)."""
+        from ai_log_analyzer.device_triage import triage_from_manager
+        try:
+            return triage_from_manager(
+                hostname, source_ids,
+                since_seconds=since_seconds, limit=limit,
+            )
+        except Exception as exc:  # noqa: BLE001 - never crash the MCP session
+            return {"ok": False, "error": str(exc)}
 
     # ── site bundle helpers ──────────────────────────────────────────────────
     @mcp.tool()

--- a/src/ai_log_analyzer/web/app.py
+++ b/src/ai_log_analyzer/web/app.py
@@ -36,6 +36,8 @@ from ai_log_analyzer import (compliance as comp_engine, copilot, diff as diff_mo
                               site_optimize, topology as topo_mod)
 from ai_log_analyzer.sources import SourceConfig, SourceError, registry  # noqa: E402
 from ai_log_analyzer.sources.manager import manager as source_manager  # noqa: E402
+from ai_log_analyzer.correlate import correlate_from_manager  # noqa: E402
+from ai_log_analyzer.device_triage import triage_from_manager  # noqa: E402
 
 STATIC_DIR = Path(__file__).parent / "static"
 SAMPLES_DIR = Path(__file__).resolve().parents[3] / "samples"
@@ -825,6 +827,48 @@ def create_app() -> Flask:
                             "message": "no events in window"})
         result = analyze(events, use_llm=_parse_bool(body.get("use_llm", True), default=True))
         return jsonify({"ok": True, "count": len(events), "result": result.to_dict()})
+
+    @app.route("/api/correlate", methods=["POST"])
+    @require_api_token
+    def api_correlate():
+        """Cross-source device correlation: which hosts surface actionable
+        events from >=2 sources (confirmed) vs 1 (suspected). Thin wrapper
+        over correlate_from_manager(); never raises for a single bad source."""
+        body = request.get_json(silent=True) or {}
+        # None => all registered sources; an explicit list selects a subset.
+        raw_ids = body.get("source_ids")
+        source_ids = [str(s) for s in raw_ids] if isinstance(raw_ids, list) else None
+        min_severity = (body.get("min_severity") or "medium").strip().lower()
+        try:
+            result = correlate_from_manager(
+                source_ids,
+                since_seconds=int(body.get("since_seconds", 3600)),
+                limit=int(body.get("limit", 5000)),
+                min_severity=min_severity,
+            )
+        except ValueError as exc:  # unknown min_severity label
+            return jsonify({"ok": False, "error": str(exc)}), 400
+        return jsonify(result)
+
+    @app.route("/api/triage", methods=["POST"])
+    @require_api_token
+    def api_triage():
+        """Per-device deep triage: verdict + health score + severity histogram
+        + top processes + deduped error patterns for one host. Thin wrapper
+        over triage_from_manager(); never raises for a single bad source."""
+        body = request.get_json(silent=True) or {}
+        hostname = (body.get("hostname") or "").strip()
+        if not hostname:
+            return jsonify({"ok": False, "error": "hostname required"}), 400
+        raw_ids = body.get("source_ids")
+        source_ids = [str(s) for s in raw_ids] if isinstance(raw_ids, list) else None
+        result = triage_from_manager(
+            hostname,
+            source_ids,
+            since_seconds=int(body.get("since_seconds", 86_400)),
+            limit=int(body.get("limit", 5000)),
+        )
+        return jsonify(result)
 
     # Auto-load env-configured sources on app boot (idempotent).
     try:

--- a/src/ai_log_analyzer/web/static/app.js
+++ b/src/ai_log_analyzer/web/static/app.js
@@ -593,6 +593,32 @@ function sevBadge(severity) {
   return el("span", { className: `sev sev-${severity}`, text: severity });
 }
 
+/** Confirmed/Suspected confidence badge — CONFIRMED is the strong/actionable
+ *  variant, SUSPECTED the muted "needs a 2nd source" variant. Pairs icon+text
+ *  so it never relies on color alone. */
+function confBadge(status, sourceCount) {
+  const confirmed = status === "confirmed";
+  return el("span", {
+    className: confirmed ? "conf conf-confirmed" : "conf conf-suspected",
+    text: `${confirmed ? "✓ CONFIRMED" : "? SUSPECTED"} · ${sourceCount} src`,
+  });
+}
+
+/** Per-source coverage pips: filled = source flagged this host, hollow = clean.
+ *  allSources is the full source_ids list from the result. */
+function sourcePips(deviceSources, allSources) {
+  const flagged = new Set(deviceSources || []);
+  const wrap = el("span", { className: "src-pips" });
+  (allSources || []).forEach((sid) => {
+    wrap.appendChild(el("span", {
+      className: "pip " + (flagged.has(sid) ? "pip-on" : "pip-off"),
+      attrs: { title: sid + (flagged.has(sid) ? " (flagged)" : " (clean)") },
+      text: "●",
+    }));
+  });
+  return wrap;
+}
+
 /** Tiny origin pill next to a hostname — tells the user where the event
  *  came from (SecureCRT recording, FRR docker logs, etc). Returns null for
  *  generic syslog so the table stays uncluttered. */
@@ -1256,6 +1282,204 @@ function renderOptimize(r) {
   clear(monUl);
   (r.monitoring_gaps || []).forEach((m) => {
     monUl.appendChild(el("li", { className: "monitoring-gap", text: m }));
+  });
+}
+
+// ── A. Cross-source correlation ───────────────────────────────────────────────
+let _correlateAllSources = [];   // captured for pip rendering / sort
+
+async function runCorrelate() {
+  const btn = $("correlate-btn");
+  const minSev = $("correlate-minsev").value;
+  const since = parseInt($("correlate-since").value, 10) || 3600;
+  btn.disabled = true; btn.setAttribute("aria-busy", "true");
+  setStatus("Correlate: scanning sources…");
+  setContext("Device · cross-source correlation");
+  $("correlate-panel").style.display = "block";
+  $("correlate-summary").textContent = "Running…";
+  clear($("correlate-table-wrap"));
+  const clearProgress = showPanelProgress("correlate-panel", "Correlating sources");
+  try {
+    const r = await fetchJSON("/api/correlate", {
+      method: "POST",
+      body: JSON.stringify({ since_seconds: since, min_severity: minSev }),
+    });
+    renderCorrelate(r);
+    setStatus(`Correlate: ${r.confirmed_count} confirmed, ${r.suspected_count} suspected `
+              + `across ${r.source_ids.length} sources`);
+    toast(`Correlation done — ${r.confirmed_count} confirmed, `
+          + `${r.suspected_count} suspected.`, "success");
+  } catch (e) {
+    $("correlate-summary").textContent = "Error: " + e.message;
+    setStatus(`Correlate error: ${e.message}`);
+    toast("Correlate error: " + e.message, "error", 6000);
+  } finally {
+    clearProgress(); btn.disabled = false; btn.removeAttribute("aria-busy");
+  }
+}
+
+function renderCorrelate(r) {
+  _correlateAllSources = r.source_ids || [];
+  const skippedN = Object.keys(r.skipped || {}).length;
+  $("correlate-summary").textContent =
+    `${r.device_count} device(s) · ${r.confirmed_count} confirmed · `
+    + `${r.suspected_count} suspected · ${r.source_ids.length} source(s)`
+    + (skippedN ? ` · ${skippedN} source(s) skipped` : "");
+
+  const wrap = $("correlate-table-wrap"); clear(wrap);
+  if (!(r.devices || []).length) {
+    wrap.appendChild(el("p", { className: "row-msg", text: "No actionable devices in window." }));
+    return;
+  }
+  // Backend already sorts confirmed-first, worst-severity, then events desc.
+  const table = el("table", { className: "events-table" });
+  const thead = el("thead", {}, el("tr", {},
+    el("th", { text: "Confidence" }), el("th", { text: "Device" }),
+    el("th", { text: "Source coverage" }), el("th", { text: "# Src" }),
+    el("th", { text: "Worst severity" }), el("th", { text: "Events" }),
+    el("th", { text: "" }),
+  ));
+  const tbody = el("tbody");
+  (r.devices || []).forEach((d) => {
+    const tr = el("tr", { className: `sev-row-${d.worst_severity || "info"}` },
+      el("td", {}, confBadge(d.status, d.source_count)),
+      el("td", {}, el("strong", { text: d.hostname })),
+      el("td", {}, sourcePips(d.sources, _correlateAllSources)),
+      el("td", { text: String(d.source_count) }),
+      el("td", {}, sevBadge(d.worst_severity || "info")),
+      el("td", { text: String(d.total_events) }),
+      el("td", {}, el("button", {
+        className: "tiny secondary",
+        text: "🔬 Triage",
+        attrs: { style: "width:auto;margin:0;padding:3px 9px;font-size:10px;" },
+        on: { click: () => triageDevice(d.hostname) },
+      })),
+    );
+    tbody.appendChild(tr);
+  });
+  table.appendChild(thead); table.appendChild(tbody);
+  wrap.appendChild(table);
+}
+
+// ── B. Per-device triage ──────────────────────────────────────────────────────
+async function runTriage() {
+  const host = $("triage-host").value.trim();
+  if (!host) { setStatus("Triage: hostname required"); toast("Triage: hostname required", "error"); return; }
+  await triageDevice(host);
+}
+
+async function triageDevice(hostname) {
+  const btn = $("triage-btn");
+  $("triage-host").value = hostname;
+  if (btn) { btn.disabled = true; btn.setAttribute("aria-busy", "true"); }
+  setStatus(`Triage: analyzing ${hostname}…`);
+  setContext(`Device · triage ${hostname}`);
+  $("triage-panel").style.display = "block";
+  $("triage-verdict").textContent = "Running…";
+  $("triage-verdict").className = "triage-verdict";
+  clear($("triage-histogram")); clear($("triage-processes")); clear($("triage-patterns"));
+  const clearProgress = showPanelProgress("triage-panel", "Triaging device");
+  try {
+    const r = await fetchJSON("/api/triage", {
+      method: "POST", body: JSON.stringify({ hostname }),
+    });
+    renderTriage(r);
+    setStatus(`Triage: ${hostname} — score ${r.health_score}/100`);
+    toast(`Triage complete — ${hostname}, score ${r.health_score}/100.`, "success");
+  } catch (e) {
+    $("triage-verdict").textContent = "Error: " + e.message;
+    setStatus(`Triage error: ${e.message}`);
+    toast("Triage error: " + e.message, "error", 6000);
+  } finally {
+    clearProgress(); if (btn) { btn.disabled = false; btn.removeAttribute("aria-busy"); }
+  }
+}
+
+// Map a 0-100 health score to a status band (verdict banner uses STATUS palette,
+// not the severity palette — per research "status ≠ severity").
+function _healthBand(score) {
+  if (score >= 80) return { cls: "ok",   label: "HEALTHY" };
+  if (score >= 50) return { cls: "warn", label: "DEGRADED" };
+  return { cls: "crit", label: "DOWN" };
+}
+
+// Order severity buckets most→least severe for the histogram (raw syslog labels
+// emitted by the backend severity_dist).
+const _RAW_SEV_ORDER = ["emerg", "alert", "crit", "error", "err", "warning", "warn", "notice", "info", "debug"];
+function _rawSevClass(raw) {
+  if (["emerg", "alert", "crit"].includes(raw)) return "critical";
+  if (["error", "err"].includes(raw))           return "high";
+  if (["warning", "warn"].includes(raw))        return "medium";
+  if (["notice"].includes(raw))                 return "low";
+  return "info";
+}
+
+function renderTriage(r) {
+  // 1. Verdict banner (status-colored) ─ top of hierarchy
+  const band = _healthBand(r.health_score);
+  const banner = $("triage-verdict");
+  banner.className = "triage-verdict band-" + band.cls;
+  banner.textContent = "";
+  banner.appendChild(el("strong", { text: `${band.label} · ${r.hostname}` }));
+  banner.appendChild(el("div", {
+    style: { fontSize: "12px", marginTop: "4px", opacity: "0.9" },
+    text: `${r.verdict} — ${r.total_events} events · top process: ${r.top_process || "—"}`
+          + (r.issue_type ? ` · ${r.issue_type}` : ""),
+  }));
+
+  // 2. Health score ring — reuse the existing gauge color-by-band convention.
+  $("triage-score").textContent = String(r.health_score);
+  const arc = $("triage-gauge-arc");
+  if (arc) {
+    const TR_CIRC = 578.05;  // matches index.html stroke-dasharray (r=92)
+    arc.setAttribute("stroke-dashoffset",
+      String(TR_CIRC * (1 - Math.max(0, Math.min(100, r.health_score)) / 100)));
+    arc.style.stroke = ({ ok: "var(--ok)", warn: "var(--warn)", crit: "var(--crit)" })[band.cls];
+  }
+
+  // 3. Severity histogram — horizontal segmented bars, most→least severe.
+  const hist = $("triage-histogram"); clear(hist);
+  const buckets = Object.entries(r.severity_dist || {})
+    .sort((a, b) => _RAW_SEV_ORDER.indexOf(a[0]) - _RAW_SEV_ORDER.indexOf(b[0]));
+  const maxCount = Math.max(1, ...buckets.map(([, c]) => c));
+  buckets.forEach(([raw, count]) => {
+    const sevCls = _rawSevClass(raw);
+    hist.appendChild(el("div", { className: "hist-row" },
+      el("span", { className: "hist-label" }, sevBadge(sevCls)),
+      el("span", {
+        className: `hist-bar sev-row-${sevCls}`,
+        style: { width: Math.round((count / maxCount) * 100) + "%" },
+      }),
+      el("span", { className: "hist-count", text: `${raw}: ${count}` }),
+    ));
+  });
+
+  // 4. Top processes (ranked, highest first — backend already sorted desc).
+  const procWrap = $("triage-processes"); clear(procWrap);
+  const ptable = el("table", { className: "events-table" });
+  ptable.appendChild(el("thead", {}, el("tr", {},
+    el("th", { text: "Process" }), el("th", { text: "Events" }), el("th", { text: "%" }))));
+  const ptbody = el("tbody");
+  (r.processes || []).slice(0, 10).forEach((p) => {
+    ptbody.appendChild(el("tr", {},
+      el("td", {}, el("strong", { text: p.process })),
+      el("td", { text: String(p.count) }),
+      el("td", { text: `${p.pct}%` })));
+  });
+  ptable.appendChild(ptbody); procWrap.appendChild(ptable);
+
+  // 5. Deduplicated error patterns — highest count first (backend sorted desc).
+  const patWrap = $("triage-patterns"); clear(patWrap);
+  if (!(r.patterns || []).length) {
+    patWrap.appendChild(el("p", { className: "row-msg", text: "No error-grade patterns." }));
+  }
+  (r.patterns || []).forEach((p) => {
+    patWrap.appendChild(el("div", { className: "finding" },
+      el("div", {},
+        sevBadge(_rawSevClass((p.severity || "").toLowerCase())), " ",
+        el("strong", { text: `×${p.count}` }), " ",
+        el("span", { className: "src-badge", text: p.app || "—" })),
+      el("div", { className: "finding-evidence", text: p.pattern })));
   });
 }
 
@@ -2352,7 +2576,7 @@ function switchSideTab(name) {
 function hideIdleStateIfAnyPanelVisible() {
   const watch = ["health-panel", "summary-panel", "actions-panel", "optimize-panel",
                   "site-panel", "topo-panel", "compliance-panel", "copilot-panel",
-                  "pm-panel", "site-wide-panel"];
+                  "pm-panel", "site-wide-panel", "correlate-panel", "triage-panel"];
   const anyVisible = watch.some((id) => {
     const el = $(id);
     return el && el.style.display !== "none" && el.style.display !== "";
@@ -2376,6 +2600,8 @@ document.addEventListener("DOMContentLoaded", () => {
   $("provider").addEventListener("change", changeProvider);
   $("run-btn").addEventListener("click", runAnalysis);
   $("opt-btn").addEventListener("click", runOptimize);
+  $("correlate-btn").addEventListener("click", runCorrelate);
+  $("triage-btn").addEventListener("click", runTriage);
   $("sample-opt-btn").addEventListener("click", runSampleOptimize);
   $("sample-picker").addEventListener("change", showSampleMeta);
   $("site-opt-btn").addEventListener("click", runSiteOptimize);

--- a/src/ai_log_analyzer/web/static/index.html
+++ b/src/ai_log_analyzer/web/static/index.html
@@ -649,6 +649,39 @@
   .sev-info     { background: rgba(139,148,158,0.12); color: var(--info);
                   border: 1px solid rgba(139,148,158,0.25); }
 
+  /* ── Confidence badges (correlation) ─────────────────────────────────── */
+  .conf { display:inline-block; padding:2px 9px; border-radius:12px;
+          font-size:10px; font-weight:700; text-transform:uppercase;
+          letter-spacing:0.4px; white-space:nowrap; }
+  .conf-confirmed { background:rgba(255,68,68,0.18); color:var(--crit);
+                    border:1px solid rgba(255,68,68,0.45); }      /* strong/actionable */
+  .conf-suspected { background:rgba(139,148,158,0.10); color:var(--info);
+                    border:1px dashed rgba(139,148,158,0.45); }   /* muted/undefined */
+
+  /* ── Source coverage pips ────────────────────────────────────────────── */
+  .src-pips { display:inline-flex; gap:3px; }
+  .src-pips .pip { font-size:11px; line-height:1; }
+  .pip-on  { color:var(--accent-2); }                              /* filled = flagged */
+  .pip-off { color:var(--info); opacity:0.35; }                    /* hollow = clean */
+
+  /* ── Triage verdict banner (STATUS palette) ──────────────────────────── */
+  .triage-verdict { padding:12px 14px; border-radius:8px; font-size:15px;
+                    font-weight:700; border-left:4px solid var(--info);
+                    background:rgba(139,148,158,0.08); }
+  .triage-verdict.band-ok   { border-left-color:var(--ok);
+                              background:rgba(63,185,80,0.10); color:var(--ok); }
+  .triage-verdict.band-warn { border-left-color:var(--warn);
+                              background:rgba(210,153,34,0.10); color:var(--warn); }
+  .triage-verdict.band-crit { border-left-color:var(--crit);
+                              background:rgba(255,68,68,0.10); color:var(--crit); }
+  .triage-verdict div { color:var(--fg, #c9d1d9); font-weight:400; }
+
+  /* ── Triage severity histogram ───────────────────────────────────────── */
+  .hist-row { display:flex; align-items:center; gap:8px; margin:3px 0; }
+  .hist-label { flex:0 0 64px; }
+  .hist-bar { height:14px; border-radius:3px; min-width:2px; }
+  .hist-count { font-size:11px; color:var(--muted); white-space:nowrap; }
+
   /* ── Code block + copy button ────────────────────────────────────────── */
   .code-block {
     position: relative;
@@ -1206,6 +1239,36 @@
         </div>
       </details>
 
+      <details class="side-section" open>
+        <summary>Cross-Source Correlation</summary>
+        <div class="side-section-body">
+          <p class="row-msg" style="margin:0 0 8px;">Find hosts flagged by ≥2 sources (confirmed) vs 1 (suspected), across all registered sources.</p>
+          <label for="correlate-minsev">Min severity</label>
+          <select id="correlate-minsev" aria-label="Minimum severity to correlate">
+            <option value="critical">Critical</option>
+            <option value="high">High</option>
+            <option value="medium" selected>Medium</option>
+            <option value="low">Low</option>
+            <option value="info">Info</option>
+          </select>
+          <label for="correlate-since">Window (seconds)</label>
+          <input id="correlate-since" type="number" value="3600" min="60" max="604800"
+                 inputmode="numeric" pattern="[0-9]*" title="Correlation time window in seconds">
+          <button id="correlate-btn" class="secondary">🔗 Correlate Sources</button>
+        </div>
+      </details>
+
+      <details class="side-section">
+        <summary>Device Triage</summary>
+        <div class="side-section-body">
+          <p class="row-msg" style="margin:0 0 8px;">Full verdict for one host: health score, severity histogram, top processes, deduped error patterns.</p>
+          <label for="triage-host">Hostname</label>
+          <input id="triage-host" placeholder="de-fra-core-01"
+                 autocomplete="off" spellcheck="false" autocapitalize="off">
+          <button id="triage-btn" class="secondary">🔬 Triage Device</button>
+        </div>
+      </details>
+
       <details class="side-section">
         <summary>Real-Config Samples</summary>
         <div class="side-section-body">
@@ -1387,6 +1450,40 @@
       <div id="opt-findings" class="panel-scroll-cap"></div>
       <h3>Monitoring Gaps</h3>
       <ul id="opt-monitoring"></ul>
+    </div>
+
+    <div class="panel" id="correlate-panel" style="display:none;">
+      <h2>🔗 Cross-Source Correlation</h2>
+      <div id="correlate-summary" style="color:var(--muted); margin-bottom:8px;"></div>
+      <div id="correlate-table-wrap" class="panel-scroll-cap"></div>
+    </div>
+
+    <div class="panel" id="triage-panel" style="display:none;">
+      <h2>🔬 Device Triage</h2>
+      <div id="triage-verdict" class="triage-verdict"></div>
+      <div class="health-wrap" style="margin-top:12px;">
+        <div class="health-left">
+          <div class="health-gauge">
+            <svg viewBox="0 0 220 220">
+              <circle class="bg-arc" cx="110" cy="110" r="92"/>
+              <circle class="fg-arc" id="triage-gauge-arc" cx="110" cy="110" r="92"
+                      stroke-dasharray="578.05" stroke-dashoffset="578.05"/>
+            </svg>
+            <div class="gauge-center">
+              <div class="score-num" id="triage-score">—</div>
+              <div style="color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:0.4px;margin-top:6px;">health</div>
+            </div>
+          </div>
+        </div>
+        <div style="flex:1;min-width:0;">
+          <h3 style="margin-top:0;">Severity Histogram</h3>
+          <div id="triage-histogram"></div>
+        </div>
+      </div>
+      <h3>Top Processes</h3>
+      <div id="triage-processes"></div>
+      <h3>Deduplicated Error Patterns</h3>
+      <div id="triage-patterns" class="panel-scroll-cap"></div>
     </div>
 
     <div class="panel" id="site-panel" style="display:none;">

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -145,3 +145,39 @@ def test_classify_events_strips_ansi_from_message_and_description():
     assert "[0;32m" not in c.message
     assert "\x1b" not in c.sample_message
     assert "\x1b" not in c.description
+
+
+# ── inetd / xinetd / ftpd pattern (Item 4 backfill) ──────────────────────────
+
+@pytest.mark.unit
+def test_inetd_classified_as_low_system():
+    ev = LogEvent("", "h1", "inetd", "info", "inetd: /usr/sbin/sshd invoked from inetd")
+    out, sev_counts, cat_counts = classify_events([ev])
+    assert out[0].severity == "low"
+    assert out[0].category == "system"
+    assert sev_counts["low"] == 1
+    assert cat_counts["system"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("appname,message", [
+    ("xinetd", "xinetd: started /usr/sbin/in.telnetd"),
+    ("ftpd", "ftpd: connection from 192.168.1.10 accepted"),
+])
+def test_xinetd_and_ftpd_match(appname: str, message: str) -> None:
+    ev = LogEvent("", "h1", appname, "info", message)
+    out, _, cat_counts = classify_events([ev])
+    assert out[0].severity == "low"
+    assert out[0].category == "system"
+
+
+@pytest.mark.unit
+def test_inetd_does_not_shadow_higher_pattern():
+    """A message containing both an ftpd token and a BGP-down token must be
+    classified by the earlier (higher-severity) BGP pattern — proving
+    first-match-wins is preserved after the new inetd tuple was inserted."""
+    ev = LogEvent("", "h1", "rpd", "err", "ftpd: bgp peer 10.0.0.1 down")
+    out, _, _ = classify_events([ev])
+    # BGP pattern (high/routing) must win over the later inetd pattern (low/system)
+    assert out[0].severity == "high"
+    assert out[0].category == "routing"

--- a/tests/test_correlate.py
+++ b/tests/test_correlate.py
@@ -1,0 +1,176 @@
+"""Unit tests for cross-source device correlation (ai_log_analyzer.correlate)."""
+from __future__ import annotations
+
+import pytest
+
+from ai_log_analyzer.classifier import LogEvent
+from ai_log_analyzer.correlate import correlate_sources
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _bgp_down_event(hostname: str) -> LogEvent:
+    """High-severity routing event (BGP peer down)."""
+    return LogEvent("2026-05-09T10:00:00", hostname, "rpd", "err",
+                    "bgp peer 10.0.0.1 down (hold timer expired)")
+
+
+def _link_down_event(hostname: str) -> LogEvent:
+    """High-severity interface event (link down)."""
+    return LogEvent("2026-05-09T10:00:00", hostname, "mib2d", "err",
+                    "snmp_trap_link_down ge-0/0/1")
+
+
+def _link_up_event(hostname: str) -> LogEvent:
+    """Medium-severity interface event (link up)."""
+    return LogEvent("2026-05-09T10:00:00", hostname, "mib2d", "info",
+                    "snmp_trap_link_up ge-0/0/2")
+
+
+def _ssh_accepted_event(hostname: str) -> LogEvent:
+    """Low-severity auth event (accepted publickey)."""
+    return LogEvent("2026-05-09T10:00:00", hostname, "sshd", "info",
+                    "accepted publickey for user admin")
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_device_in_two_sources_is_confirmed():
+    """A device with actionable events in >=2 sources must be 'confirmed'."""
+    events_by_source = {
+        "kibana": [_bgp_down_event("fra4-fw-01")],
+        "librenms": [_link_down_event("fra4-fw-01")],
+    }
+    result = correlate_sources(events_by_source)
+
+    assert result["ok"] is True
+    assert result["confirmed_count"] == 1
+    assert result["suspected_count"] == 0
+
+    device = result["confirmed"][0]
+    assert device["hostname"] == "fra4-fw-01"
+    assert device["status"] == "confirmed"
+    assert device["source_count"] == 2
+    assert sorted(device["sources"]) == ["kibana", "librenms"]
+
+
+@pytest.mark.unit
+def test_device_in_one_source_is_suspected():
+    """A device with actionable events in exactly 1 source must be 'suspected'."""
+    events_by_source = {
+        "kibana": [_bgp_down_event("fra4-fw-01")],
+    }
+    result = correlate_sources(events_by_source)
+
+    assert result["ok"] is True
+    assert result["confirmed_count"] == 0
+    assert result["suspected_count"] == 1
+
+    device = result["suspected"][0]
+    assert device["status"] == "suspected"
+    assert device["source_count"] == 1
+
+
+@pytest.mark.unit
+def test_short_hostname_intersection():
+    """FQDN and short form of the same device must be correlated as ONE device."""
+    events_by_source = {
+        "kibana": [_bgp_down_event("fra4-fw-01.dc.example.com")],
+        "librenms": [_link_down_event("fra4-fw-01")],
+    }
+    result = correlate_sources(events_by_source)
+
+    # Should correlate as a single confirmed device.
+    assert result["confirmed_count"] == 1
+    assert result["suspected_count"] == 0
+    assert result["confirmed"][0]["hostname"] == "fra4-fw-01"
+
+
+@pytest.mark.unit
+def test_low_and_info_events_excluded():
+    """Low-severity events must not contribute to correlation (default medium threshold)."""
+    events_by_source = {
+        "kibana": [_ssh_accepted_event("fra4-fw-01")],
+        "librenms": [_ssh_accepted_event("fra4-fw-01")],
+    }
+    result = correlate_sources(events_by_source)
+
+    # The SSH event is low/auth — below the medium threshold.
+    assert result["device_count"] == 0
+    assert result["confirmed_count"] == 0
+    assert result["suspected_count"] == 0
+
+
+@pytest.mark.unit
+def test_min_severity_high_drops_medium():
+    """With min_severity='high', a medium event in the 2nd source must not count."""
+    events_by_source = {
+        "kibana": [_bgp_down_event("fra4-fw-01")],      # high
+        "librenms": [_link_up_event("fra4-fw-01")],     # medium
+    }
+    result = correlate_sources(events_by_source, min_severity="high")
+
+    # Only the 'kibana' high-sev event counts; librenms medium is excluded.
+    assert result["confirmed_count"] == 0
+    assert result["suspected_count"] == 1
+    assert result["suspected"][0]["sources"] == ["kibana"]
+
+
+@pytest.mark.unit
+def test_worst_severity_and_sorting():
+    """A device with critical events must sort before one with only mediums."""
+    crit_event = LogEvent("2026-05-09T10:00:00", "fra4-sw-01", "kernel", "crit",
+                          "kernel panic - not syncing")
+    med_event = _link_up_event("fra4-rt-01")
+
+    events_by_source = {
+        "kibana": [crit_event, med_event],
+        "librenms": [crit_event, med_event],
+    }
+    result = correlate_sources(events_by_source)
+
+    assert result["confirmed_count"] == 2
+    devices = result["confirmed"]
+    # Critical device should be first.
+    critical_device = next(d for d in devices if d["hostname"] == "fra4-sw-01")
+    medium_device = next(d for d in devices if d["hostname"] == "fra4-rt-01")
+    assert critical_device["worst_severity"] == "critical"
+    assert medium_device["worst_severity"] == "medium"
+    assert devices.index(critical_device) < devices.index(medium_device)
+
+
+@pytest.mark.unit
+def test_invalid_min_severity_raises():
+    """Passing an unknown min_severity must raise ValueError."""
+    with pytest.raises(ValueError, match="bogus"):
+        correlate_sources({}, min_severity="bogus")
+
+
+@pytest.mark.unit
+def test_empty_input_returns_zero_counts():
+    """An empty events_by_source dict must return a valid zero-count result."""
+    result = correlate_sources({})
+
+    assert result["ok"] is True
+    assert result["device_count"] == 0
+    assert result["confirmed_count"] == 0
+    assert result["suspected_count"] == 0
+    assert result["confirmed"] == []
+    assert result["suspected"] == []
+    assert result["devices"] == []
+
+
+@pytest.mark.unit
+def test_input_not_mutated():
+    """correlate_sources must not mutate the caller's input dict or its lists."""
+    original_event = _bgp_down_event("fra4-fw-01")
+    original_list = [original_event]
+    events_by_source = {"kibana": original_list}
+
+    correlate_sources(events_by_source)
+
+    # Dict structure and list contents must be identical.
+    assert list(events_by_source.keys()) == ["kibana"]
+    assert events_by_source["kibana"] is original_list
+    assert events_by_source["kibana"] == [original_event]

--- a/tests/test_device_triage.py
+++ b/tests/test_device_triage.py
@@ -1,0 +1,207 @@
+"""Unit tests for per-device deep triage (ai_log_analyzer.device_triage)."""
+from __future__ import annotations
+
+import pytest
+
+from ai_log_analyzer.classifier import LogEvent
+from ai_log_analyzer.device_triage import normalize_pattern, triage_device
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_event(
+    hostname: str = "h1",
+    appname: str = "rpd",
+    severity_raw: str = "err",
+    message: str = "bgp peer 10.0.0.1 down",
+) -> LogEvent:
+    """Convenience constructor for a LogEvent."""
+    return LogEvent("2026-05-09T10:00:00", hostname, appname, severity_raw, message)
+
+
+# ── normalize_pattern tests ───────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_normalize_strips_hex_pid_ip():
+    """normalize_pattern must replace hex addresses, PIDs, and IPs with tokens."""
+    raw = "rpd[1234]: peer 10.0.0.1 at 0xdeadbeef reset"
+    key = normalize_pattern(raw)
+
+    assert "[N]" in key
+    assert "IP" in key
+    assert "0xADDR" in key
+
+    # Originals must be gone.
+    assert "1234" not in key
+    assert "10.0.0.1" not in key
+    assert "0xdeadbeef" not in key
+
+
+@pytest.mark.unit
+def test_normalize_truncates_to_120_chars():
+    """normalize_pattern must truncate output to 120 characters."""
+    long_msg = "x" * 300
+    assert len(normalize_pattern(long_msg)) <= 120
+
+
+@pytest.mark.unit
+def test_normalize_empty_string():
+    """normalize_pattern must handle empty input gracefully."""
+    assert normalize_pattern("") == ""
+
+
+# ── triage_device tests ───────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_pattern_frequency_dedup():
+    """Events that differ only by IP/PID must collapse to ONE pattern with count == 3."""
+    events = [
+        _make_event(message="rpd[100]: peer 10.0.0.1 at 0xaaaa reset"),
+        _make_event(message="rpd[200]: peer 10.0.0.2 at 0xbbbb reset"),
+        _make_event(message="rpd[300]: peer 10.0.0.3 at 0xcccc reset"),
+    ]
+    result = triage_device("h1", events)
+
+    assert len(result.patterns) == 1
+    assert result.patterns[0]["count"] == 3
+
+
+@pytest.mark.unit
+def test_non_error_severity_excluded_from_patterns():
+    """An 'info' event must produce no pattern entry."""
+    events = [
+        _make_event(severity_raw="info", message="rpd[1]: bgp peer up"),
+    ]
+    result = triage_device("h1", events)
+
+    assert result.patterns == []
+
+
+@pytest.mark.unit
+def test_verdict_hardware_from_fpc_process():
+    """Events from fpc0 with err severity must yield a HARDWARE FAILURE verdict."""
+    events = [
+        _make_event(appname="fpc0", severity_raw="err",
+                    message="fpc0 parity error at slot 0"),
+    ]
+    result = triage_device("h1", events)
+
+    assert result.issue_type == "hardware"
+    assert result.verdict.startswith("HARDWARE FAILURE")
+
+
+@pytest.mark.unit
+def test_verdict_routing_from_rpd():
+    """Events from rpd with err severity must yield a ROUTING ISSUE verdict."""
+    events = [
+        _make_event(appname="rpd", severity_raw="err",
+                    message="bgp peer 10.0.0.1 down hold timer expired"),
+    ]
+    result = triage_device("h1", events)
+
+    assert result.issue_type == "routing"
+    assert result.verdict.startswith("ROUTING ISSUE")
+
+
+@pytest.mark.unit
+def test_verdict_security_from_sshd():
+    """sshd with error-grade events (e.g. auth failures) yields 'security'."""
+    events = [
+        _make_event(appname="sshd", severity_raw="err",
+                    message="error: maximum authentication attempts exceeded for admin"),
+    ]
+    result = triage_device("h1", events)
+
+    assert result.issue_type == "security"
+    assert "SSH" in result.verdict
+
+
+@pytest.mark.unit
+def test_sshd_info_only_is_not_security():
+    """Pure sshd info logins (no errors anywhere) must NOT be flagged 'security' —
+    that would mislabel a healthy device. Expect a clean/info verdict."""
+    events = [
+        _make_event(appname="sshd", severity_raw="info",
+                    message="accepted publickey for admin from 192.168.1.1"),
+    ]
+    result = triage_device("h1", events)
+
+    assert result.issue_type == "info"
+
+
+@pytest.mark.unit
+def test_verdict_info_when_clean():
+    """Clean info events must yield an INFORMATIONAL verdict with health_score == 100."""
+    events = [
+        _make_event(appname="mgd", severity_raw="info",
+                    message="UI_COMMIT: User 'admin' done"),
+        _make_event(appname="snmpd", severity_raw="info",
+                    message="snmp trap sent"),
+    ]
+    result = triage_device("h1", events)
+
+    assert result.issue_type == "info"
+    assert result.verdict.startswith("INFORMATIONAL")
+    assert result.health_score == 100
+
+
+@pytest.mark.unit
+def test_score_drops_with_criticals():
+    """Many crit events must lower health_score below 100, capped by the formula."""
+    n = 10  # 10 crit events -> 10*5=50 penalty -> score = 50
+    events = [
+        _make_event(severity_raw="crit", message=f"critical failure {i}")
+        for i in range(n)
+    ]
+    result = triage_device("h1", events)
+
+    expected_max = 100 - min(n * 5, 50)
+    assert result.health_score < 100
+    assert result.health_score <= expected_max
+
+
+@pytest.mark.unit
+def test_processes_sorted_desc_with_pct():
+    """processes must be sorted descending by count; pct values must sum ~100."""
+    events = [
+        _make_event(appname="rpd", severity_raw="err"),
+        _make_event(appname="rpd", severity_raw="err"),
+        _make_event(appname="rpd", severity_raw="err"),
+        _make_event(appname="mib2d", severity_raw="info"),
+        _make_event(appname="mib2d", severity_raw="info"),
+        _make_event(appname="sshd", severity_raw="info"),
+    ]
+    result = triage_device("h1", events)
+
+    # First process must be the most frequent one.
+    assert result.processes[0]["process"] == "rpd"
+    assert result.processes[0]["count"] == 3
+
+    # Pct values must sum approximately to 100.
+    total_pct = sum(p["pct"] for p in result.processes)
+    assert abs(total_pct - 100.0) <= 0.5
+
+
+@pytest.mark.unit
+def test_empty_events_clean_verdict():
+    """Empty event list must yield total_events==0, 'No events found', score 100."""
+    result = triage_device("h1", [])
+
+    assert result.total_events == 0
+    assert result.verdict == "No events found"
+    assert result.health_score == 100
+    assert result.issue_type == "info"
+    assert result.processes == []
+    assert result.patterns == []
+
+
+@pytest.mark.unit
+def test_input_not_mutated():
+    """triage_device must not mutate the caller's events list."""
+    original_event = _make_event()
+    original_list = [original_event]
+
+    triage_device("h1", original_list)
+
+    assert original_list == [original_event]
+    assert len(original_list) == 1

--- a/tests/test_kb_rca.py
+++ b/tests/test_kb_rca.py
@@ -1,0 +1,97 @@
+"""Tests for DCN _AI_KB RCA enrichment merged into kb.py (Item 2)."""
+from __future__ import annotations
+
+import pytest
+
+from ai_log_analyzer import kb
+
+
+_PHASE_NAMES = {"Diagnose", "Mitigate", "Remediate", "Verify", "Optimize"}
+_RCA_KEYS = {"root_cause", "risk", "resolution_steps", "cli_junos", "cli_eos", "timeline"}
+
+
+@pytest.mark.unit
+def test_vpn_category_exists_and_phased() -> None:
+    """vpn category must exist and every non-default entry must carry 5 phases."""
+    e = kb.lookup("vpn", "ipsec tunnel down")
+    assert "phases" in e, "vpn entry must contain 'phases'"
+    names = {p["name"] for p in e["phases"]}
+    assert names.issuperset(_PHASE_NAMES), f"vpn entry missing phases: {_PHASE_NAMES - names}"
+
+
+@pytest.mark.unit
+def test_redundancy_category_exists_and_phased() -> None:
+    """redundancy category must exist and carry all 5 phases."""
+    e = kb.lookup("redundancy", "vrrp master change")
+    assert "phases" in e, "redundancy entry must contain 'phases'"
+    names = {p["name"] for p in e["phases"]}
+    assert names.issuperset(_PHASE_NAMES), f"redundancy entry missing phases: {_PHASE_NAMES - names}"
+
+
+@pytest.mark.unit
+def test_hardware_fpc_subpattern_matches() -> None:
+    """lookup('hardware', 'fpc0 offline crash') must resolve to FPC entry with RCA mentioning FPC/line card."""
+    e = kb.lookup("hardware", "fpc0 offline crash")
+    assert "rca" in e, "FPC hardware entry must have an 'rca' block"
+    root = e["rca"]["root_cause"].upper()
+    assert "FPC" in root or "LINE CARD" in root, (
+        f"rca.root_cause should mention FPC or line card, got: {e['rca']['root_cause']!r}"
+    )
+
+
+@pytest.mark.unit
+def test_hardware_chassis_subpattern_matches() -> None:
+    """lookup('hardware', 'chassis alarm power supply fail') must resolve to chassis entry."""
+    e = kb.lookup("hardware", "chassis alarm power supply fail")
+    assert "rca" in e, "Chassis hardware entry must have an 'rca' block"
+    root = e["rca"]["root_cause"].lower()
+    # Should mention PSU, fan, or temperature
+    assert any(kw in root for kw in ("psu", "fan", "power supply", "temperature", "thermal")), (
+        f"rca.root_cause should mention PSU/fan/temperature for chassis entry, got: {root!r}"
+    )
+
+
+@pytest.mark.unit
+def test_rca_block_has_dcn_fields() -> None:
+    """BGP routing entry must expose all 6 DCN RCA fields, with non-empty lists."""
+    e = kb.lookup("routing", "bgp peer down")
+    assert "rca" in e, "BGP entry must have an 'rca' block"
+    rca = e["rca"]
+    assert _RCA_KEYS == set(rca.keys()), (
+        f"rca must have exactly {_RCA_KEYS}, got {set(rca.keys())}"
+    )
+    assert isinstance(rca["resolution_steps"], list) and len(rca["resolution_steps"]) > 0, \
+        "rca.resolution_steps must be a non-empty list"
+    assert isinstance(rca["cli_junos"], list) and len(rca["cli_junos"]) > 0, \
+        "rca.cli_junos must be a non-empty list"
+    assert isinstance(rca["cli_eos"], list) and len(rca["cli_eos"]) > 0, \
+        "rca.cli_eos must be a non-empty list"
+
+
+@pytest.mark.unit
+def test_rca_does_not_break_phases() -> None:
+    """Every entry that has an 'rca' block must also still have 'phases' with 5 phase names."""
+    seen: set[int] = set()
+    for cat, entries in kb.KB.items():
+        for key, entry in entries.items():
+            if id(entry) in seen:
+                continue
+            seen.add(id(entry))
+            if "rca" not in entry:
+                continue
+            assert "phases" in entry, (
+                f"{cat}.{key}: entry has 'rca' but is missing 'phases'"
+            )
+            names = {p["name"] for p in entry["phases"]}
+            assert names.issuperset(_PHASE_NAMES), (
+                f"{cat}.{key}: rca entry missing phases — got {names}"
+            )
+
+
+@pytest.mark.unit
+def test_resolution_steps_are_strings() -> None:
+    """All resolution_steps in the BGP RCA block must be plain strings."""
+    e = kb.lookup("routing", "bgp peer down")
+    rca = e["rca"]
+    for step in rca["resolution_steps"]:
+        assert isinstance(step, str), f"resolution_steps must contain strings, got {type(step)}: {step!r}"

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,20 @@
+"""Smoke test: verify _build_server() constructs without errors.
+
+Ensures that all @mcp.tool() wrappers compile and register correctly.
+Skipped gracefully when the MCP SDK is not installed.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+@pytest.mark.unit
+def test_build_server_registers_new_tools():
+    """_build_server() must succeed (raises if any @mcp.tool() body is malformed)."""
+    from ai_log_analyzer.mcp_server.server import _build_server
+
+    srv = _build_server()
+    # FastMCP keeps tools in an internal registry; just assert construction works.
+    assert srv is not None

--- a/tests/test_web_correlate_triage.py
+++ b/tests/test_web_correlate_triage.py
@@ -1,0 +1,170 @@
+"""Route-wrapper tests for /api/correlate and /api/triage.
+
+These exercise the thin Flask wrappers (body parsing, validation, envelope
+pass-through, error status codes) with the backend correlate/triage functions
+mocked — no live SourceManager is touched.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from ai_log_analyzer.web.app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+_CORRELATE_OK = {
+    "ok": True,
+    "source_ids": [],
+    "device_count": 0,
+    "confirmed_count": 0,
+    "suspected_count": 0,
+    "confirmed": [],
+    "suspected": [],
+    "devices": [],
+    "skipped": {},
+}
+
+_TRIAGE_OK = {
+    "ok": True,
+    "hostname": "r1",
+    "total_events": 0,
+    "severity_dist": {},
+    "processes": [],
+    "patterns": [],
+    "verdict": "INFORMATIONAL",
+    "issue_type": "info",
+    "health_score": 100,
+    "top_process": "",
+    "sources": [],
+    "skipped": {},
+}
+
+
+# ── /api/correlate ───────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_correlate_empty_body_uses_all_sources(client):
+    with patch("ai_log_analyzer.web.app.correlate_from_manager",
+               return_value=dict(_CORRELATE_OK)) as mock:
+        resp = client.post("/api/correlate", json={})
+    assert resp.status_code == 200
+    mock.assert_called_once()
+    args, kwargs = mock.call_args
+    assert args[0] is None
+    assert kwargs["since_seconds"] == 3600
+    assert kwargs["min_severity"] == "medium"
+    assert resp.get_json()["ok"] is True
+
+
+@pytest.mark.unit
+def test_correlate_passes_source_ids_and_minsev(client):
+    with patch("ai_log_analyzer.web.app.correlate_from_manager",
+               return_value=dict(_CORRELATE_OK)) as mock:
+        resp = client.post("/api/correlate", json={
+            "source_ids": ["kibana", "librenms"],
+            "min_severity": "high",
+            "since_seconds": 600,
+        })
+    assert resp.status_code == 200
+    args, kwargs = mock.call_args
+    assert args[0] == ["kibana", "librenms"]
+    assert kwargs["since_seconds"] == 600
+    assert kwargs["min_severity"] == "high"
+
+
+@pytest.mark.unit
+def test_correlate_bad_min_severity_returns_400(client):
+    with patch("ai_log_analyzer.web.app.correlate_from_manager",
+               side_effect=ValueError("Unknown min_severity 'bogus'.")):
+        resp = client.post("/api/correlate", json={"min_severity": "bogus"})
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "Unknown" in body["error"]
+
+
+@pytest.mark.unit
+def test_correlate_non_list_source_ids_coerced_to_none(client):
+    with patch("ai_log_analyzer.web.app.correlate_from_manager",
+               return_value=dict(_CORRELATE_OK)) as mock:
+        resp = client.post("/api/correlate", json={"source_ids": "kibana"})
+    assert resp.status_code == 200
+    args, _ = mock.call_args
+    assert args[0] is None
+
+
+@pytest.mark.unit
+def test_correlate_envelope_passthrough(client):
+    full = dict(_CORRELATE_OK)
+    full.update(confirmed_count=2, suspected_count=1)
+    with patch("ai_log_analyzer.web.app.correlate_from_manager",
+               return_value=full):
+        resp = client.post("/api/correlate", json={})
+    assert resp.status_code == 200
+    assert resp.get_json() == full
+
+
+# ── /api/triage ──────────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_triage_missing_hostname_returns_400(client):
+    resp = client.post("/api/triage", json={})
+    assert resp.status_code == 400
+    assert resp.get_json() == {"ok": False, "error": "hostname required"}
+
+
+@pytest.mark.unit
+def test_triage_blank_hostname_returns_400(client):
+    resp = client.post("/api/triage", json={"hostname": "   "})
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+
+
+@pytest.mark.unit
+def test_triage_calls_backend_with_defaults(client):
+    with patch("ai_log_analyzer.web.app.triage_from_manager",
+               return_value=dict(_TRIAGE_OK)) as mock:
+        resp = client.post("/api/triage", json={"hostname": "r1"})
+    assert resp.status_code == 200
+    args, kwargs = mock.call_args
+    assert args[0] == "r1"
+    assert args[1] is None
+    assert kwargs["since_seconds"] == 86_400
+    assert kwargs["limit"] == 5000
+    assert resp.get_json()["ok"] is True
+
+
+@pytest.mark.unit
+def test_triage_passes_source_ids_and_window(client):
+    with patch("ai_log_analyzer.web.app.triage_from_manager",
+               return_value=dict(_TRIAGE_OK)) as mock:
+        resp = client.post("/api/triage", json={
+            "hostname": "r1",
+            "source_ids": ["kibana"],
+            "since_seconds": 3600,
+            "limit": 200,
+        })
+    assert resp.status_code == 200
+    args, kwargs = mock.call_args
+    assert args[1] == ["kibana"]
+    assert kwargs["since_seconds"] == 3600
+    assert kwargs["limit"] == 200
+
+
+@pytest.mark.unit
+def test_triage_envelope_passthrough(client):
+    full = dict(_TRIAGE_OK)
+    full.update(health_score=42, verdict="DEGRADED")
+    with patch("ai_log_analyzer.web.app.triage_from_manager",
+               return_value=full):
+        resp = client.post("/api/triage", json={"hostname": "r1"})
+    assert resp.status_code == 200
+    assert resp.get_json() == full


### PR DESCRIPTION
Harvests the genuinely-novel logic from the legacy DCN AI Intelligence tool that netlog-ai lacked, adapted to the `LogEvent`/`SourceManager` model.

## What's added
- **Cross-source correlation** (`correlate.py` + MCP tool `correlate_sources`): a device with actionable events in **≥2 sources** is `confirmed`, 1 source is `suspected`. O(N) over events, FQDN→short-host normalization.
- **Per-device deep triage** (`device_triage.py` + MCP tool `analyze_device`): error-pattern dedup (hex/IP/PID normalization), process breakdown, health score, verdict chain. `sshd` verdict gated on real error-grade events so healthy login-only devices aren't mislabelled.
- **Richer RCA knowledge base** (`kb.py`): merged DCN `_AI_KB` content (root_cause/risk/resolution_steps/cli_junos/cli_eos) **additively** into existing phased entries + new vpn/redundancy/fpc/chassis categories. Backward compatible.
- **Classifier backfill** (`classifier.py`): the one missing DCN syslog pattern (`inetd|xinetd|ftpd` → low/system), first-match ordering preserved.

## Quality
- **227 tests pass** (192 baseline + 35 new), `ruff` clean, 0 regressions.
- **Stress-tested**: correlation 1,200 devices in 0.02s (no quadratic blowup), triage 10k events in 0.008s.
- Code-review pass fixed 1 HIGH (MCP tool exception wrapper) + 3 MEDIUM (immutability, None-vs-empty source semantics, sshd over-firing).

## Surface area
Exposed as **2 new MCP tools** + importable library functions. **No web-GUI wiring yet** (follow-up).

## Docs
`docs/PORTED_FROM_DCN_AI.md` + README what's-new + `CONNECTORS.md` MCP table.