### PR TITLE
docs: freshen test counts (139->237) + drop broken screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
-![screenshot](docs/screenshot.png)
-
 ---
 
 ## Why this exists
@@ -394,7 +392,7 @@ src/ai_log_analyzer/
 
 ## Tested & accessible
 
-- **139 unit + integration tests** (pytest, ~0.2s suite)
+- **237 unit + integration tests** (pytest)
 - Frontend audited across 8 review rounds:
   - WCAG-AA: `:focus-visible` rings, `aria-live` regions, `role=tablist/tab/tabpanel`, skip-to-main link, `prefers-reduced-motion` fallback
   - Responsive ≤ 1100px, PWA-ready (`theme-color`, `mobile-web-app-capable`, SVG favicon)

--- a/docs/LINKEDIN_POST.md
+++ b/docs/LINKEDIN_POST.md
@@ -14,7 +14,7 @@
 > 🚀 **No telemetry, no SaaS** — configs never leave the host.
 > 🎯 **Multi-vendor from day one** — Junos, Arista, and FRR are all first-class. Not a chatbot retrofit.
 > ♿ **WCAG-AA accessible** — axe-core verified across every UI state. Full keyboard nav, ARIA, reduced-motion, dark color-scheme.
-> 🧪 **139 tests passing** across 8 review rounds — classifier, sanitizer, topology inference, LLM providers, site analysis.
+> 🧪 **237 tests passing** across 8 review rounds — classifier, sanitizer, topology inference, LLM providers, site analysis.
 >
 > 📦 Bundled with two synthetic demo sites (11 devices total, mixed Junos + Arista EOS) so every feature runs end-to-end the moment you clone.
 >
@@ -66,7 +66,7 @@
 | 0:25–0:50 | DEVICE tab | Switch to DEVICE, pick `junos-fw-01` sample, click Optimize → LLM auditing → findings populate with severity badges, code blocks (Proposed Patch, Rollback, Verify CLI), Copy All Patches button, toast "Optimization complete" | "Audit a device config — LLM produces patches + rollback + verify CLI" → "Findings with severity, evidence, proposed patch, rollback, verify CLI" |
 | 0:50–1:25 | SITE tab | Switch to SITE, pick `lab-bravo`, Analyze Whole Site → cross-device findings populate, then Topology → D3 force-directed map with 6 nodes, legend visible | "Or analyze a full site bundle" → "Cross-device gap analysis — BGP, OSPF, MTU, missing BFD…" → "D3 force-directed topology inferred from configs alone" |
 | 1:25–1:42 | Copilot | AI Copilot section opens, "Which devices are missing BFD on BGP?" types, Ask Copilot fires → LLM streams a markdown answer listing all affected devices | "Ask the LLM questions about the loaded site" → "Context-grounded answer — LLM never sees raw secrets (pre-sanitized)" |
-| 1:42–1:47 | Outro | Scroll to top, clean dashboard, outro caption | "github.com/gesh75/netlog-ai · MIT · 139 tests passing" |
+| 1:42–1:47 | Outro | Scroll to top, clean dashboard, outro caption | "github.com/gesh75/netlog-ai · MIT · 237 tests passing" |
 
 **Total runtime: 1:47 (107 seconds)** — comfortably under the 2-minute target.
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -415,6 +415,6 @@
 
   <!-- Legend dot pulse animation -->
   <g transform="translate(640,700)" text-anchor="middle">
-    <text font-size="10" fill="#6b7280">github.com/gesh75/netlog-ai · MIT · 139 tests passing</text>
+    <text font-size="10" fill="#6b7280">github.com/gesh75/netlog-ai · MIT · 237 tests passing</text>
   </g>
 </svg>


### PR DESCRIPTION
Documentation freshness pass after the DCN-AI port landed:
- README test count 139 -> **237**; removed the dead `docs/screenshot.png` image reference.
- `docs/architecture.svg` + `docs/LINKEDIN_POST.md`: `139` -> `237` tests passing.

Docs-only; README tool list already includes `correlate_sources`/`analyze_device`.