### PR TITLE
ci: add GitHub Actions CI + fix lint/deprecation debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: pip install -e ".[dev,all]"
+      - name: Lint
+        run: ruff check src/ tests/
+      - name: Test
+        run: pytest -p no:warnings --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 out/
 frames/
 node_modules/
+
+# Lint caches
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > **Network logs in. Ranked actions out.** A local, dark-themed dashboard that classifies syslog events from any vendor (Junos, Arista EOS, FRR), builds a prioritized action list, and lets an LLM write the root-cause analysis with copy-pastable CLI fixes.
 
-![Tests](https://img.shields.io/badge/tests-237%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
+[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-237%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,7 @@ markers = [
 [tool.ruff]
 line-length = 110
 target-version = "py310"
+
+[tool.ruff.lint]
+# E701/E702: compact one-line guards (`if x: return y`) are the established style here
+ignore = ["E701", "E702"]

--- a/src/ai_log_analyzer/compliance.py
+++ b/src/ai_log_analyzer/compliance.py
@@ -166,7 +166,7 @@ def _evaluate_rule(text: str, rule: dict[str, Any]) -> tuple[bool, str]:
     any_pats = rule.get("must_match_any", [])
     if any_pats:
         if not any(re.search(p, text, re.M | re.I) for p in any_pats):
-            return False, f"None of the required patterns matched"
+            return False, "None of the required patterns matched"
 
     return True, "ok"
 

--- a/src/ai_log_analyzer/diff.py
+++ b/src/ai_log_analyzer/diff.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import difflib
 import re
-from typing import Iterable
 
 from ai_log_analyzer import llm
 from ai_log_analyzer.sanitize import sanitize

--- a/src/ai_log_analyzer/llm.py
+++ b/src/ai_log_analyzer/llm.py
@@ -290,7 +290,7 @@ def _query_unix_socket(sock_path: str, api_path: str, payload: dict) -> Optional
         if b"Transfer-Encoding: chunked" in resp:
             lines = body_bytes.split(b"\r\n")
             body_bytes = b"".join(
-                l for l in lines if l and not all(c in b"0123456789abcdefABCDEF" for c in l)
+                ln for ln in lines if ln and not all(c in b"0123456789abcdefABCDEF" for c in ln)
             )
         data = json.loads(body_bytes.strip())
         return _extract_openai_text(data)

--- a/src/ai_log_analyzer/postmortem.py
+++ b/src/ai_log_analyzer/postmortem.py
@@ -6,7 +6,6 @@ like, automatically check every other device for the same fingerprint.
 from __future__ import annotations
 
 import re
-from typing import Iterable
 
 
 def search_fleet(

--- a/src/ai_log_analyzer/reports.py
+++ b/src/ai_log_analyzer/reports.py
@@ -17,9 +17,8 @@ import html
 import shutil
 import subprocess
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -32,7 +31,7 @@ def to_markdown_site(result: dict) -> str:
     site = result.get("site_id", "(site)")
     out.append(f"# Site Analysis: {site}")
     out.append("")
-    out.append(f"_Generated {datetime.utcnow().isoformat(timespec='seconds')}Z_  ")
+    out.append(f"_Generated {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')}Z_  ")
     out.append(f"_LLM: {'on' if result.get('llm_powered') else 'rule-based'}_")
     out.append("")
     out.append(f"**Maturity score:** {result.get('site_score', 0)}/100")
@@ -99,7 +98,7 @@ def to_markdown_optimize(result: dict) -> str:
     out: list[str] = []
     out.append(f"# Device Optimization Report: {result.get('hostname', '(device)')}")
     out.append("")
-    out.append(f"_Generated {datetime.utcnow().isoformat(timespec='seconds')}Z_  ")
+    out.append(f"_Generated {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')}Z_  ")
     out.append(f"_Platform: {result.get('platform', '?')}  |  "
                f"LLM: {'on' if result.get('llm_powered') else 'rule-based'}_")
     out.append("")
@@ -165,7 +164,7 @@ def to_html_site(result: dict, mermaid_diagram: str | None = None) -> str:
     site = result.get("site_id", "(site)")
     findings = result.get("cross_device_findings") or []
     topo = result.get("topology") or {}
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     findings_html = []
     for i, f in enumerate(findings, 1):

--- a/src/ai_log_analyzer/runbook.py
+++ b/src/ai_log_analyzer/runbook.py
@@ -26,12 +26,6 @@ def to_ansible_playbook(
         cmds = ["# No platform-specific commands found in the finding"]
 
     hosts_block = ", ".join(hostnames) or "all"
-    module = {
-        "junos": "junipernetworks.junos.junos_command",
-        "eos":   "arista.eos.eos_config",
-        "frr":   "ansible.builtin.shell",
-    }.get(platform_hint.lower(), "ansible.builtin.shell")
-
     if platform_hint.lower() == "frr":
         task_body = "      ansible.builtin.shell: |\n" + indent("\n".join(cmds), "        ")
     elif platform_hint.lower() == "eos":

--- a/src/ai_log_analyzer/site_diagram.py
+++ b/src/ai_log_analyzer/site_diagram.py
@@ -11,12 +11,12 @@ If graphviz `dot` is installed, can also render to PNG/SVG.
 """
 from __future__ import annotations
 
+import ipaddress as _ip
 import re
 import shutil
 import subprocess
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Iterable
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -173,7 +173,6 @@ _EOS_VLAN_SUBNET = re.compile(
 )
 
 # Public IP detection — anything outside RFC1918 / link-local / loopback
-import ipaddress as _ip
 
 
 def _is_public_ip(ip: str) -> bool:
@@ -621,7 +620,7 @@ def build_site_dot(
             lines.append('        flow2_sw [label="Mgmt Switch\\n' +
                           f'VLAN {mgmt_vlans[0].vlan_id}", fillcolor="#66cc66"];')
             if fws:
-                lines.append(f'        flow2_fw [label="Firewall\\nMgmt Zone", fillcolor="#ff6666", shape=component];')
+                lines.append('        flow2_fw [label="Firewall\\nMgmt Zone", fillcolor="#ff6666", shape=component];')
                 lines.append('        flow2_sw -> flow2_fw [color="#cc9900"];')
                 lines.append('        flow2_dev [label="Network\\nDevices", shape=box3d, fillcolor="#ffcc99"];')
                 lines.append('        flow2_fw -> flow2_dev [color="#cc9900"];')

--- a/src/ai_log_analyzer/site_doc.py
+++ b/src/ai_log_analyzer/site_doc.py
@@ -611,7 +611,7 @@ def render_site_doc(
     out.append(f"- **Inferred Country/Region:** {country}")
     out.append(f"- **Network Devices in this bundle:** {len(profiles)}")
     funcs = Counter(p.function_code for p in profiles)
-    out.append(f"- **Device functions:** "
+    out.append("- **Device functions:** "
                + ", ".join(f"{n}× `{f}`" for f, n in funcs.most_common()))
     out.append("")
     out.append("> _Facility metadata (rack count, exact address, contact) is not derivable from sanitized configs — pull from NetBox or DCIM for production reports._")
@@ -790,12 +790,12 @@ def _executive_summary(site: str, profiles: list[DeviceProfile],
     lines: list[str] = []
     lines.append(f"🏢 **Site Status:** ACTIVE — {len(profiles)} devices ({dict(by_role)})")
     lines.append("")
-    lines.append(f"🎯 **Priority Classification:** "
+    lines.append("🎯 **Priority Classification:** "
                  + ("**Tier 1** (full firewall + multiple switches)"
                     if by_role.get("firewall", 0) >= 1 and by_role.get("switch", 0) >= 4
                     else "**Tier 2** (limited size)"))
     lines.append("")
-    lines.append(f"📊 **Infrastructure Overview:**")
+    lines.append("📊 **Infrastructure Overview:**")
     lines.append(f"- {by_role.get('firewall', 0)} firewall(s), "
                  f"{by_role.get('router', 0)} router(s), "
                  f"{by_role.get('switch', 0)} switch(es)")
@@ -998,7 +998,7 @@ def _bgp_routing_section(profiles: list[DeviceProfile], isps: list) -> list[str]
     out: list[str] = []
     if not total:
         return ["_No BGP neighbors detected across the site._"]
-    out.append(f"### 8.1 BGP Footprint")
+    out.append("### 8.1 BGP Footprint")
     out.append("")
     out.append(f"- **Total BGP neighbor configurations:** {total}")
     out.append(f"- **Devices with BGP:** {sum(1 for p in profiles if p.bgp_neighbors)}")

--- a/src/ai_log_analyzer/sources/kibana.py
+++ b/src/ai_log_analyzer/sources/kibana.py
@@ -16,7 +16,6 @@ import requests
 
 from ai_log_analyzer.classifier import LogEvent
 from ai_log_analyzer.sources.base import (
-    LogSource,
     SourceConfig,
     SourceError,
     SourceTimeoutError,

--- a/src/ai_log_analyzer/sources/librenms.py
+++ b/src/ai_log_analyzer/sources/librenms.py
@@ -15,7 +15,6 @@ import requests
 
 from ai_log_analyzer.classifier import LogEvent
 from ai_log_analyzer.sources.base import (
-    LogSource,
     SourceConfig,
     SourceError,
     SourceTimeoutError,

--- a/src/ai_log_analyzer/sources/loki.py
+++ b/src/ai_log_analyzer/sources/loki.py
@@ -19,7 +19,6 @@ import requests
 
 from ai_log_analyzer.classifier import LogEvent
 from ai_log_analyzer.sources.base import (
-    LogSource,
     SourceConfig,
     SourceError,
     SourceTimeoutError,

--- a/src/ai_log_analyzer/sources/manager.py
+++ b/src/ai_log_analyzer/sources/manager.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from typing import Iterable
 
 from ai_log_analyzer.classifier import LogEvent
 from ai_log_analyzer.sources.base import LogSource, SourceConfig, SourceError, registry

--- a/src/ai_log_analyzer/sources/splunk.py
+++ b/src/ai_log_analyzer/sources/splunk.py
@@ -19,7 +19,6 @@ import requests
 
 from ai_log_analyzer.classifier import LogEvent
 from ai_log_analyzer.sources.base import (
-    LogSource,
     SourceConfig,
     SourceError,
     SourceTimeoutError,

--- a/src/ai_log_analyzer/sources/syslog.py
+++ b/src/ai_log_analyzer/sources/syslog.py
@@ -19,7 +19,7 @@ from typing import Iterable
 
 from ai_log_analyzer.adapters.file import parse_lines
 from ai_log_analyzer.classifier import LogEvent
-from ai_log_analyzer.sources.base import LogSource, SourceConfig, SourceError, registry
+from ai_log_analyzer.sources.base import SourceConfig, SourceError, registry
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -214,7 +214,7 @@ def test_scrub_placeholders_passthrough_when_no_placeholders():
 @pytest.mark.unit
 def test_executive_summary_llm_prompt_anchors_hostnames(monkeypatch):
     """The LLM call must receive an ALLOWED_HOSTNAMES line and real device names."""
-    from ai_log_analyzer import analyzer, llm
+    from ai_log_analyzer import llm
     from ai_log_analyzer.analyzer import ActionItem, _executive_summary
 
     captured = {}


### PR DESCRIPTION
## Summary
- **First CI for this repo**: GitHub Actions workflow running `ruff check` + the full 237-test pytest suite on a Python 3.10/3.11/3.12 matrix, on every push to `main` and every PR. Live CI badge added to README.
- **Fix `datetime.utcnow()` deprecation** in `reports.py` (3 call sites) — replaced with timezone-aware `datetime.now(timezone.utc)`; the rendered timestamp format is byte-identical (the two `…Z`-suffixed sites use `strftime` to avoid a double `+00:00Z` suffix).
- **Lint debt to zero**: 94 ruff errors → 0. Auto-fixed 11 unused imports + 6 placeholder-less f-strings; hand-fixed ambiguous `l` (llm.py), mid-file import (site_diagram.py), dead `module` dict (runbook.py). E701/E702 (compact one-line guards) declared as project style in `pyproject.toml`.
- **Hygiene**: `.ruff_cache/` gitignored.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `pytest` — 237/237 passing locally (Python 3.12 venv)
- [ ] CI matrix green on 3.10/3.11/3.12 (first run, this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce GitHub Actions CI and bring the codebase in line with linting and datetime best practices.

Bug Fixes:
- Replace deprecated datetime.utcnow() usage with timezone-aware datetime.now(timezone.utc) while preserving existing timestamp formats.

Enhancements:
- Tidy report and site rendering code strings for style consistency and readability.
- Remove unused variables, imports, and obsolete logic to reduce dead code and improve maintainability.
- Declare compact one-line guard style in Ruff configuration to align linting rules with project conventions.

CI:
- Add a GitHub Actions workflow running Ruff and the full pytest suite across Python 3.10–3.12 on pushes to main and pull requests.
- Expose CI status via a GitHub Actions badge in the README.

Chores:
- Ignore Ruff cache directories in version control to keep the repository clean.