### PR TITLE
fix: close analyze_site sanitize bypass + harden web API + perf wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ loose semantic versioning.
 
 ## [Unreleased]
 
+### Security
+
+- **Closed the `analyze_site()` sanitize bypass** — site-wide cross-device analysis
+  sent raw `config_text` to the LLM provider; it now routes every device config
+  through `sanitize(mask_pii=True)` like the other LLM paths, locked in by a
+  regression test (`tests/test_site_sanitize.py`).
+- **Confined `POST /api/analyze {source:"file"}`** to allowlisted roots
+  (home + `/var/log` + the checkout; override with `AI_LOG_ANALYZER_FILE_ROOTS`).
+  Previously any reachable caller could read arbitrary files via the API.
+- `GET /api/llm/status` no longer exposes `last_errors` (upstream error bodies) to
+  anonymous callers when an API token is configured.
+- CDN `<script>` tags now carry Subresource Integrity hashes.
+
+### Changed
+
+- **Anthropic prompt caching**: system prompts are sent with
+  `cache_control: ephemeral` — repeat analyses bill cached input at ~10% price.
+- Static text assets use `Cache-Control: no-cache` (ETag revalidation → 304s)
+  instead of `no-store` re-downloading ~200KB per page view.
+- Dropped the unused D3 bundle (280KB on every page load; `app.js` never used it).
+- Version is reported from package metadata (fixed the `ai-log-analyzer` →
+  `netlog-ai` distribution-name mismatch that pinned `/api/health` to a hardcoded
+  fallback); `pyproject.toml` bumped to 0.2.0 to match.
+- Added `CONTRIBUTING.md` (the README already linked it; the file didn't exist).
+- `tests/test_sources.py` no longer depends on test execution order
+  (registry registration is now a per-test fixture). Suite: 237 → 246 tests.
+
 ### Added — DCN AI Intelligence port (cross-source correlation + per-device triage)
 
 Four capabilities harvested from the legacy DCN AI Intelligence tool and re-targeted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for your interest in netlog-ai. The short version:
+
+## Setup
+
+```bash
+git clone https://github.com/gesh75/netlog-ai.git
+cd netlog-ai
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,all]"
+```
+
+## Before you open a PR
+
+```bash
+ruff check src/ tests/   # must be clean
+pytest                   # full suite must pass
+```
+
+Both run in CI (Python 3.10–3.12) on every PR — see `.github/workflows/ci.yml`.
+
+## Guidelines
+
+- **Commits:** conventional format — `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`.
+- **Tests:** new behavior ships with tests. Bug fixes ship with a regression test.
+- **Sanitize-before-LLM:** any new code path that sends text to an LLM provider
+  must route configs through `sanitize()` first. This is the project's core
+  privacy guarantee — PRs that bypass it will be rejected.
+- **Samples:** never commit real device configs. Use RFC 5737/3849 documentation
+  prefixes, private ASNs (64512–65534), and pseudonymized hostnames.
+
+## Reporting issues
+
+Use [GitHub Issues](https://github.com/gesh75/netlog-ai/issues). For suspected
+security issues (e.g. a sanitization bypass), please mark the issue clearly.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > **Network logs in. Ranked actions out.** A local, dark-themed dashboard that classifies syslog events from any vendor (Junos, Arista EOS, FRR), builds a prioritized action list, and lets an LLM write the root-cause analysis with copy-pastable CLI fixes.
 
-[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-237%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
+[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-246%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -392,7 +392,7 @@ src/ai_log_analyzer/
 
 ## Tested & accessible
 
-- **237 unit + integration tests** (pytest)
+- **246 unit + integration tests** (pytest)
 - Frontend audited across 8 review rounds:
   - WCAG-AA: `:focus-visible` rings, `aria-live` regions, `role=tablist/tab/tabpanel`, skip-to-main link, `prefers-reduced-motion` fallback
   - Responsive ≤ 1100px, PWA-ready (`theme-color`, `mobile-web-app-capable`, SVG favicon)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netlog-ai"
-version = "0.1.0"
+version = "0.2.0"
 description = "AI-powered network syslog analyzer with pluggable LLM providers (local Docker Model Runner / Anthropic Claude) and lab adapters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/ai_log_analyzer/__init__.py
+++ b/src/ai_log_analyzer/__init__.py
@@ -20,7 +20,9 @@ from importlib.metadata import (
 )
 
 try:
-    __version__: str = _pkg_version("ai-log-analyzer")
+    # The distribution is named "netlog-ai" (pyproject [project].name); the
+    # old "ai-log-analyzer" lookup never matched and always hit the fallback.
+    __version__: str = _pkg_version("netlog-ai")
 except _PkgNFE:
     __version__ = "0.2.0"  # fallback for non-installed / editable dev checkouts
 

--- a/src/ai_log_analyzer/analyzer.py
+++ b/src/ai_log_analyzer/analyzer.py
@@ -728,9 +728,13 @@ def analyze_site(
         cfg = d.get("config_text") or ""
         if not cfg:
             continue
-        trimmed = cfg[:PER_DEVICE_CHARS]
-        if len(cfg) > PER_DEVICE_CHARS:
-            trimmed += f"\n... [config truncated, original {len(cfg)} chars] ..."
+        # CRITICAL: same belt-and-suspenders as optimize_config — site bundles
+        # can carry live-fetched or user-supplied raw configs, so scrub secrets
+        # + PII here before anything reaches an external LLM.
+        safe_cfg, _ = sanitize(cfg, mask_pii=True)
+        trimmed = safe_cfg[:PER_DEVICE_CHARS]
+        if len(safe_cfg) > PER_DEVICE_CHARS:
+            trimmed += f"\n... [config truncated, original {len(safe_cfg)} chars] ..."
         block = (
             f"\n\n========== DEVICE: {d['hostname']} ==========\n"
             f"FUNCTION: {d.get('function', 'unknown')}  |  PLATFORM: {d.get('platform', 'unknown')}\n"

--- a/src/ai_log_analyzer/llm.py
+++ b/src/ai_log_analyzer/llm.py
@@ -202,7 +202,15 @@ def _query_claude(system_prompt: str, user_prompt: str, max_tokens: int) -> Opti
             json={
                 "model": _state["anthropic_model"],
                 "max_tokens": max_tokens,
-                "system": system_prompt,
+                # cache_control: the static system prompts are re-sent on every
+                # analysis call — marking them ephemeral lets the API serve them
+                # from prompt cache at ~10% of input price on repeat calls.
+                # Ignored harmlessly below the model's cacheable minimum.
+                "system": [{
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }],
                 "messages": [{"role": "user", "content": user_prompt}],
             },
             timeout=int(_state["timeout"]),

--- a/src/ai_log_analyzer/web/app.py
+++ b/src/ai_log_analyzer/web/app.py
@@ -26,7 +26,7 @@ from functools import wraps  # noqa: E402
 from flask import Flask, abort, jsonify, request, send_from_directory  # noqa: E402
 from flask_cors import CORS  # noqa: E402
 
-from ai_log_analyzer import llm  # noqa: E402
+from ai_log_analyzer import __version__, llm  # noqa: E402
 from ai_log_analyzer.adapters import frr, network_tool  # noqa: E402
 from ai_log_analyzer.adapters.file import parse_lines  # noqa: E402
 from ai_log_analyzer.analyzer import analyze, analyze_site, optimize_config  # noqa: E402
@@ -47,6 +47,27 @@ SITES_DIR = Path(__file__).resolve().parents[3] / "sites"
 # ── Security helpers ─────────────────────────────────────────────────────────
 
 API_TOKEN: str = os.environ.get("AI_LOG_ANALYZER_API_TOKEN", "")
+
+# Roots that POST /api/analyze {source:"file"} may read from. Colon-separated
+# env override; default = home + /var/log + the repo checkout. Confines the
+# unauthenticated file-ingest path so an exposed port can't read /etc/* etc.
+FILE_ROOTS: list[Path] = [
+    Path(p).expanduser().resolve()
+    for p in os.environ.get(
+        "AI_LOG_ANALYZER_FILE_ROOTS",
+        f"{Path.home()}:/var/log:{Path(__file__).resolve().parents[3]}",
+    ).split(":")
+    if p.strip()
+]
+
+
+def _path_allowed(p: Path) -> bool:
+    """True when the resolved path sits under one of FILE_ROOTS."""
+    try:
+        resolved = p.resolve()
+    except OSError:
+        return False
+    return any(resolved.is_relative_to(root) for root in FILE_ROOTS)
 
 
 class BadCommand(ValueError):
@@ -160,9 +181,10 @@ def create_app() -> Flask:
     # ── Cache headers for static HTML/JS/CSS ──────────────────────────────
     # The UI is a single-page Flask app — we ship layout/JS fixes by editing
     # index.html and app.js directly. Browsers cache these by default, which
-    # means users see a stale UI until they hard-refresh. Force revalidation
-    # on every request for the text assets; binary assets (images, video) are
-    # still cached normally.
+    # means users see a stale UI until they hard-refresh. `no-cache` (without
+    # `no-store`) forces revalidation via If-None-Match on every request, so
+    # Flask's ETag answers 304 and the ~200KB of text assets are only
+    # re-downloaded when they actually change. Binary assets stay cached.
     @app.after_request
     def _add_no_cache_for_text_assets(response):
         path = (request.path or "").lower()
@@ -171,9 +193,7 @@ def create_app() -> Flask:
                 or path.endswith(".js")
                 or path.endswith(".css")
                 or path.endswith(".json")):
-            response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-            response.headers["Pragma"] = "no-cache"
-            response.headers["Expires"] = "0"
+            response.headers["Cache-Control"] = "no-cache"
         return response
 
     # ── UI ────────────────────────────────────────────────────────────────
@@ -186,13 +206,19 @@ def create_app() -> Flask:
     def health():
         return jsonify({
             "ok": True,
-            "version": "0.2.0",
+            "version": __version__,
             "network_tool_available": network_tool.is_available(),
         })
 
     @app.route("/api/llm/status", methods=["GET"])
     def llm_status():
-        return jsonify(llm.get_state())
+        state = llm.get_state()
+        # last_errors carries upstream HTTP error bodies — useful in the UI,
+        # but on a token-protected deployment don't hand it to anonymous
+        # callers. Dev mode (no token) keeps full output for the dashboard.
+        if API_TOKEN and request.headers.get("X-API-Token", "") != API_TOKEN:
+            state = {k: v for k, v in state.items() if k != "last_errors"}
+        return jsonify(state)
 
     @app.route("/api/llm/provider", methods=["POST"])
     @require_api_token
@@ -587,7 +613,12 @@ def create_app() -> Flask:
 
         elif source == "file":
             path = body.get("path", "")
-            p = Path(path) if path else None
+            p = Path(path).expanduser() if path else None
+            if p and not _path_allowed(p):
+                return jsonify({
+                    "error": "Path outside allowed roots "
+                             "(set AI_LOG_ANALYZER_FILE_ROOTS to extend)",
+                }), 403
             if not p or not p.exists():
                 return jsonify({"error": f"Path not found: {path}"}), 404
             from ai_log_analyzer.adapters.file import (

--- a/src/ai_log_analyzer/web/static/index.html
+++ b/src/ai_log_analyzer/web/static/index.html
@@ -9,11 +9,8 @@
 <meta name="description" content="AI-powered network log analyzer with cross-device correlation, BGP/OSPF health scoring, and LLM-assisted incident playbooks.">
 <!-- Local-only tool: keep out of any accidental search-engine crawl if the port is exposed -->
 <meta name="robots" content="noindex, nofollow">
-<!-- D3 CDN preconnect — opens TCP+TLS 100–200ms earlier so the deferred D3
-     script downloads faster on first paint. `crossorigin` matches the script's
-     CORS mode (D3 is served with permissive CORS). -->
-<link rel="preconnect" href="https://d3js.org" crossorigin>
-<link rel="dns-prefetch" href="https://d3js.org">
+<!-- CDN preconnect — opens TCP+TLS 100–200ms earlier so the deferred
+     topology scripts download faster on first paint. -->
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
 <!-- PWA: when added to iOS / Android home screen, launch full-screen with status bar tinted to match the dark theme -->
@@ -1603,15 +1600,20 @@
   </section>
 </main>
 
-<!-- `defer` keeps execution order (D3 → cytoscape → elkjs → cytoscape-elk → app.js)
+<!-- `defer` keeps execution order (cytoscape → elkjs → cytoscape-elk → app.js)
      while letting the parser work uninterrupted. All scripts run after
      DOMContentLoaded, which the app's init handler already expects.
-     - D3 is still used for a few small renderers; cytoscape is the topology engine.
+     - cytoscape is the topology engine (D3 was dropped — app.js never used it).
      - elkjs must load before cytoscape-elk (which registers the adapter). -->
-<script src="https://d3js.org/d3.v7.min.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.4/dist/cytoscape.min.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/elkjs@0.9.3/lib/elk.bundled.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/cytoscape-elk@2.2.0/dist/cytoscape-elk.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.4/dist/cytoscape.min.js" defer
+        integrity="sha384-H3uzGzTfGHUAumB8+s4GEdfFwzAceN9wCCndN8AXubWKFIPuBSWKKtWDx7RhSf/z"
+        crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/elkjs@0.9.3/lib/elk.bundled.js" defer
+        integrity="sha384-KO35c6PFq7tFxAEx6FtATwL9vOBOmCzQYr7GM0iTr3oO22s7Jc9OkclOH4AV7jwK"
+        crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/cytoscape-elk@2.2.0/dist/cytoscape-elk.js" defer
+        integrity="sha384-2kn1Dn9ABocPd1Sy3vo1Df4fl4mW7zyR9V15SruidezT1rmZL5i8b/BAFMBNddKT"
+        crossorigin="anonymous"></script>
 <script src="app.js" defer></script>
 </body>
 </html>

--- a/tests/test_site_sanitize.py
+++ b/tests/test_site_sanitize.py
@@ -1,0 +1,61 @@
+"""Regression: analyze_site() must sanitize device configs before the LLM call.
+
+The sanitize-before-LLM guarantee held for copilot.ask / optimize_config /
+diff but analyze_site() shipped raw config_text into the prompt. This locks
+the fix in place.
+"""
+from __future__ import annotations
+
+import pytest
+
+import ai_log_analyzer.analyzer as analyzer_mod
+from ai_log_analyzer.analyzer import analyze_site
+
+_SECRET_CONFIG = """\
+system {
+    root-authentication {
+        encrypted-password "$6$rounds=5000$abcdef$VerySecretHash123";
+    }
+}
+snmp {
+    community topsecret-rw-community {
+        authorization read-write;
+    }
+}
+protocols {
+    bgp {
+        group ebgp-peers {
+            neighbor 192.0.2.1;
+        }
+    }
+}
+"""
+
+
+@pytest.mark.unit
+def test_analyze_site_never_sends_raw_secrets_to_llm(monkeypatch):
+    captured: dict = {}
+
+    def fake_query(system_prompt, user_prompt, max_tokens=4096, **kw):
+        captured["system"] = system_prompt
+        captured["user"] = user_prompt
+        return None  # LLM failure path is fine — we only need the prompt
+
+    monkeypatch.setattr(analyzer_mod.llm, "query", fake_query)
+    monkeypatch.setattr(analyzer_mod.llm, "get_state", lambda: {"enabled": True})
+
+    analyze_site("test-site", [{
+        "hostname": "fw-01",
+        "function": "firewall",
+        "platform": "junos",
+        "config_text": _SECRET_CONFIG,
+    }])
+
+    assert "user" in captured, "analyze_site never reached llm.query"
+    prompt = captured["user"]
+    # secrets scrubbed
+    assert "VerySecretHash123" not in prompt
+    assert "topsecret-rw-community" not in prompt
+    # but the config structure still reaches the LLM
+    assert "fw-01" in prompt
+    assert "root-authentication" in prompt

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -54,6 +54,15 @@ class _StubSource:
         self._closed = True
 
 
+@pytest.fixture(autouse=True)
+def _isolated_stub_registration():
+    """Register 'stub-test' for every test and clean up the shared registry
+    singleton afterwards — keeps tests order-independent (xdist/-k safe)."""
+    registry.register("stub-test", _StubSource.from_config)
+    yield
+    registry._factories.pop("stub-test", None)
+
+
 @pytest.mark.unit
 def test_stub_source_satisfies_protocol():
     cfg = SourceConfig(id="s1", type="stub", url="http://x")

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1,0 +1,98 @@
+"""Security-gate tests: API-token enforcement, file-ingest path confinement,
+and llm/status redaction for anonymous callers on tokened deployments.
+"""
+from __future__ import annotations
+
+import pytest
+
+import ai_log_analyzer.web.app as web_app
+from ai_log_analyzer.web.app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# require_api_token
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_token_unset_decorator_is_noop(client, monkeypatch):
+    monkeypatch.setattr(web_app, "API_TOKEN", "")
+    r = client.post("/api/llm/provider", json={})
+    assert r.status_code != 401
+
+
+@pytest.mark.unit
+def test_token_set_rejects_missing_and_wrong_token(client, monkeypatch):
+    monkeypatch.setattr(web_app, "API_TOKEN", "sekrit")
+    assert client.post("/api/llm/provider", json={}).status_code == 401
+    r = client.post("/api/llm/provider", json={},
+                    headers={"X-API-Token": "wrong"})
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_token_set_accepts_correct_token(client, monkeypatch):
+    monkeypatch.setattr(web_app, "API_TOKEN", "sekrit")
+    r = client.post("/api/llm/provider", json={},
+                    headers={"X-API-Token": "sekrit"})
+    assert r.status_code != 401  # passes the gate; body validation may 400
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# /api/analyze {source:"file"} path confinement
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_file_source_outside_roots_is_403(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(web_app, "FILE_ROOTS", [tmp_path / "allowed"])
+    r = client.post("/api/analyze", json={"source": "file", "path": "/etc/hosts"})
+    assert r.status_code == 403
+    assert "allowed roots" in r.get_json()["error"]
+
+
+@pytest.mark.unit
+def test_file_source_inside_roots_is_served(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(web_app, "FILE_ROOTS", [tmp_path])
+    log = tmp_path / "dev.log"
+    log.write_text(
+        "Jan  1 00:00:01 r1 rpd[123]: BGP_NEIGHBOR_DOWN: peer 192.0.2.1 down\n"
+    )
+    r = client.post("/api/analyze",
+                    json={"source": "file", "path": str(log), "use_llm": False})
+    assert r.status_code == 200
+    assert len(r.get_json()["classified_events"]) >= 1
+
+
+@pytest.mark.unit
+def test_file_source_traversal_is_blocked(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(web_app, "FILE_ROOTS", [tmp_path / "allowed"])
+    sneaky = str(tmp_path / "allowed" / ".." / "secret.log")
+    r = client.post("/api/analyze", json={"source": "file", "path": sneaky})
+    assert r.status_code == 403
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# /api/llm/status redaction
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_llm_status_hides_last_errors_from_anonymous_when_tokened(client, monkeypatch):
+    monkeypatch.setattr(web_app, "API_TOKEN", "sekrit")
+    state = client.get("/api/llm/status").get_json()
+    assert "last_errors" not in state
+    state = client.get("/api/llm/status",
+                       headers={"X-API-Token": "sekrit"}).get_json()
+    assert "last_errors" in state
+
+
+@pytest.mark.unit
+def test_llm_status_full_in_dev_mode(client, monkeypatch):
+    monkeypatch.setattr(web_app, "API_TOKEN", "")
+    state = client.get("/api/llm/status").get_json()
+    assert "last_errors" in state


### PR DESCRIPTION
## Summary
Wave 2 from the multi-agent gap review (27 evidence-verified findings across security / product / performance / tests). This PR lands every small-effort, high-value fix:

### Security
- **`analyze_site()` sanitize bypass (HIGH)** — the site-wide cross-device path embedded **raw** `config_text` in the LLM prompt while every sibling path (copilot, optimize_config, diff) sanitizes. Now each device config goes through `sanitize(mask_pii=True)`, with `tests/test_site_sanitize.py` asserting secrets/SNMP communities never reach `llm.query`.
- **Arbitrary file read via `POST /api/analyze {source:"file"}` (MEDIUM)** — path is now confined to allowlisted roots (home + `/var/log` + checkout; `AI_LOG_ANALYZER_FILE_ROOTS` to extend). Traversal outside roots → 403.
- **`/api/llm/status` info leak (LOW)** — `last_errors` (upstream HTTP error bodies) is stripped for anonymous callers when an API token is configured; dev mode unchanged so the dashboard keeps its error display.
- **SRI** integrity hashes added to the three CDN script tags.

### Performance / cost
- **Anthropic prompt caching** — `cache_control: ephemeral` on system prompts (~90% input-token saving on repeat analyses with the live Claude provider).
- **`Cache-Control: no-cache` instead of `no-store`** — ETag revalidation now returns 304s; previously ~200KB of HTML/JS was fully re-downloaded on every page view while the ETag sat unused.
- **Dropped dead D3** — 280KB loaded on every page; `grep d3\. app.js` → zero usages (the 'still used by a few renderers' comment was stale).

### Product hygiene
- **Version plumbing fixed** — `importlib.metadata.version("ai-log-analyzer")` never matched the actual dist name `netlog-ai`, so the fallback hardcode always won. pyproject bumped 0.1.0 → 0.2.0 (matching the long-advertised `/api/health` version); health route now reports the real package version.
- **CONTRIBUTING.md added** — README has linked it since the OSS launch; the file didn't exist (404 on the public page).
- **Test order-independence** — `test_sources.py` manager tests relied on registry pollution from an earlier test (failed under `-k`/xdist); now a per-test fixture.

## Test plan
- [x] `ruff check` clean
- [x] **246/246 tests pass** (237 existing + 9 new: 8 web-security + 1 sanitize regression)
- [x] `pytest tests/test_sources.py -k manager` passes in isolation (order-dependence fixed)
- [ ] CI matrix green (3.10/3.11/3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden LLM- and file-related web API surfaces, enforce sanitize-before-LLM for site analysis, tune caching for performance, and tidy versioning, docs, and tests.

Bug Fixes:
- Ensure analyze_site() sanitizes device configs before including them in LLM prompts to prevent secret leakage.
- Restrict /api/analyze file-source requests to configurable allowlisted roots and reject traversal outside those roots.
- Hide last_errors from unauthenticated callers on token-protected /api/llm/status while preserving full output in dev mode.

Enhancements:
- Switch static text assets to Cache-Control: no-cache so browsers can revalidate via ETag instead of re-downloading on every page view.
- Enable Anthropic prompt caching by marking system prompts as ephemeral to reduce repeated input token costs.
- Report the application version from the netlog-ai package metadata and align the project version to 0.2.0.
- Remove the unused D3 dependency from the frontend and add SRI hashes to remaining CDN script tags.

Documentation:
- Add CONTRIBUTING.md with setup, testing, and contribution guidelines, including sanitize-before-LLM requirements.
- Update README and CHANGELOG to reflect new version, test counts, security changes, and performance tweaks.

Tests:
- Add web security tests for API token enforcement, file-ingest confinement, and /api/llm/status redaction behavior.
- Add a regression test ensuring analyze_site() never sends unsanitized secrets to the LLM provider.
- Make source manager tests order-independent via an autouse fixture that isolates registry state.