### PR TITLE
perf: 2.3x faster classification via parse-tree literal gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ loose semantic versioning.
 
 ## [Unreleased]
 
+### Performance
+
+- **Classifier literal gate: 2.3× faster classification** (1.2 → 2.7 MB/s on the
+  sample corpus, identical results). Guaranteed literal keywords are extracted
+  from each KB pattern's parse tree at import; lines containing none of them
+  (the vast majority of real syslog) skip the ordered 75-regex loop entirely.
+  Sound by construction — patterns with no provable literal stay always-checked —
+  and self-maintaining as KB rules are added. Equivalence + invariants pinned by
+  `tests/test_classifier_gate.py`.
+
 ### Distribution & data privacy (wave 3)
 
 - **Wheels are now self-contained**: `samples/`, `sites/`, and the entire web UI

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > **Network logs in. Ranked actions out.** A local, dark-themed dashboard that classifies syslog events from any vendor (Junos, Arista EOS, FRR), builds a prioritized action list, and lets an LLM write the root-cause analysis with copy-pastable CLI fixes.
 
-[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-252%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
+[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-256%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -392,7 +392,7 @@ src/ai_log_analyzer/
 
 ## Tested & accessible
 
-- **252 unit + integration tests** (pytest)
+- **256 unit + integration tests** (pytest)
 - Frontend audited across 8 review rounds:
   - WCAG-AA: `:focus-visible` rings, `aria-live` regions, `role=tablist/tab/tabpanel`, skip-to-main link, `prefers-reduced-motion` fallback
   - Responsive ≤ 1100px, PWA-ready (`theme-color`, `mobile-web-app-capable`, SVG favicon)

--- a/src/ai_log_analyzer/classifier.py
+++ b/src/ai_log_analyzer/classifier.py
@@ -81,6 +81,87 @@ _COMPILED: list[tuple[re.Pattern[str], str, str, str]] = [
     (re.compile(p, re.IGNORECASE), s, c, d) for (p, s, c, d) in _KB_PATTERNS
 ]
 
+# ── Fast-path literal gate ───────────────────────────────────────────────
+# In real syslog the vast majority of lines match no KB pattern, yet each one
+# paid all ~75 regex scans. The gate below extracts, from every pattern's
+# parse tree, a set of literal keywords such that a line CANNOT match the
+# pattern without containing one of them. A cheap str-in scan over those
+# keywords then decides whether the ordered regex loop needs to run at all.
+# Patterns where no literal can be proven stay in an always-checked list, so
+# the gate is sound by construction and self-maintains as rules are added.
+
+try:  # Python 3.11+ moved sre_parse under re._parser
+    from re import _parser as _sre_parse  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - Python 3.10
+    import sre_parse as _sre_parse  # type: ignore[import-not-found]
+
+
+def _guaranteed_literals(parsed) -> set[str] | None:
+    """Lowercase literals, ≥1 of which appears in any match; None = no proof."""
+    best: set[str] | None = None
+    runs: list[str] = []
+    run: list[str] = []
+
+    def _flush() -> None:
+        if run:
+            runs.append("".join(run))
+            run.clear()
+
+    def _prefer(cur: set[str] | None, new: set[str] | None) -> set[str] | None:
+        if not new: return cur
+        if cur is None: return new
+        return new if len(new) < len(cur) else cur
+
+    for op, av in parsed:
+        name = op.name
+        if name == "LITERAL":
+            run.append(chr(av).lower())
+            continue
+        _flush()
+        if name == "SUBPATTERN":  # av = (group, add_flags, del_flags, sub)
+            best = _prefer(best, _guaranteed_literals(av[3]))
+        elif name == "BRANCH":  # av = (None, [alternatives])
+            union: set[str] = set()
+            for alt in av[1]:
+                alt_lits = _guaranteed_literals(alt)
+                if not alt_lits:
+                    union = set()
+                    break
+                union |= alt_lits
+            best = _prefer(best, union)
+        elif name in ("MAX_REPEAT", "MIN_REPEAT"):  # av = (min, max, item)
+            if av[0] >= 1:  # only required (non-optional) repeats guarantee
+                best = _prefer(best, _guaranteed_literals(av[2]))
+        # IN / ANY / AT / NOT_LITERAL etc. prove nothing — skip
+    _flush()
+
+    solid = [r for r in runs if len(r) >= 3] or runs
+    if solid:
+        return {max(solid, key=len)}
+    return best
+
+
+_KEYWORDS: tuple[str, ...]
+_UNGUARDED: list[tuple[re.Pattern[str], str, str, str]] = []
+_kw: set[str] = set()
+for _i, (_p, _s, _c, _d) in enumerate(_KB_PATTERNS):
+    try:
+        _lits = _guaranteed_literals(_sre_parse.parse(_p))
+    except Exception:  # unparseable construct — never skip this pattern
+        _lits = None
+    # Literals under 3 chars match almost every line and would neuter the
+    # gate — such patterns go to the always-checked list instead.
+    if _lits and all(len(_l) >= 3 for _l in _lits):
+        _kw |= _lits
+    else:
+        _UNGUARDED.append(_COMPILED[_i])
+# Prune redundant keywords: if k2 is a substring of k1, any line containing
+# k1 also contains k2 — k2 alone suffices for the gate.
+_KEYWORDS = tuple(sorted(
+    k for k in _kw
+    if not any(other != k and other in k for other in _kw)
+))
+
 # ANSI/VT100 terminal escape sequences — systemd, journald, FRR vtysh, and
 # any source piping colored output leaks these into the message field.
 # Pattern covers CSI (\x1b[...m), OSC (\x1b]...\x07), and SGR-style codes.
@@ -181,7 +262,13 @@ def classify_events(events: Iterable[LogEvent]) -> tuple[list[ClassifiedEvent], 
         combined = f"{ev.appname} {clean_message}".lower()
         sev, cat, desc = "info", "other", ""
 
-        for pattern, p_sev, p_cat, p_desc in _COMPILED:
+        # Literal gate: no keyword → only the unproven patterns can possibly
+        # match (their relative order is preserved, so precedence holds).
+        if any(k in combined for k in _KEYWORDS):
+            candidates = _COMPILED
+        else:
+            candidates = _UNGUARDED
+        for pattern, p_sev, p_cat, p_desc in candidates:
             if pattern.search(combined):
                 sev, cat, desc = p_sev, p_cat, p_desc
                 break

--- a/tests/test_classifier_gate.py
+++ b/tests/test_classifier_gate.py
@@ -1,0 +1,64 @@
+"""Literal-gate soundness: the keyword fast path must never change results.
+
+The gate skips the ordered 75-pattern loop for lines that provably cannot
+match any guarded pattern. These tests pin the equivalence and the gate's
+structural invariants so KB additions can't silently break either.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ai_log_analyzer import classifier
+from ai_log_analyzer.adapters.file import parse_file
+from ai_log_analyzer.classifier import LogEvent, classify_events
+
+SAMPLES = Path(__file__).resolve().parents[1] / "src" / "ai_log_analyzer" / "data" / "samples"
+
+
+@pytest.mark.unit
+def test_gate_equivalent_to_full_loop_on_sample_corpus(monkeypatch):
+    events = []
+    for f in SAMPLES.glob("*.txt"):
+        events.extend(parse_file(f))
+    assert events, "sample corpus is empty"
+
+    gated = classify_events(events)
+
+    # Disable the gate: empty keyword set routes every line through the
+    # "unguarded" path, which we point at the full ordered pattern table.
+    monkeypatch.setattr(classifier, "_KEYWORDS", ())
+    monkeypatch.setattr(classifier, "_UNGUARDED", classifier._COMPILED)
+    reference = classify_events(events)
+
+    assert gated == reference
+
+
+@pytest.mark.unit
+def test_gate_invariants():
+    assert all(len(k) >= 3 for k in classifier._KEYWORDS), \
+        "short keyword would fire on every line and neuter the gate"
+    assert len(classifier._UNGUARDED) <= 5, \
+        "too many unguarded patterns — extraction regressed"
+    assert len(classifier._KEYWORDS) >= 30, "suspiciously few keywords extracted"
+
+
+@pytest.mark.unit
+def test_guarded_pattern_still_matches():
+    events = [LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
+                       appname="rpd", severity_raw="err",
+                       message="BGP peer 192.0.2.1 (External AS 64900) down")]
+    classified, sev_counts, _ = classify_events(events)
+    assert classified[0].severity == "high"
+    assert classified[0].category == "routing"
+
+
+@pytest.mark.unit
+def test_unmatched_line_stays_info():
+    events = [LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
+                       appname="cron", severity_raw="info",
+                       message="job 42 completed normally")]
+    classified, sev_counts, _ = classify_events(events)
+    assert classified[0].severity == "info"
+    assert sev_counts["info"] == 1


### PR DESCRIPTION
## Summary
Addresses the verified perf finding: *'75 sequential regex searches per line caps throughput at ~2-4 MB/s'*.

## Approach
- **Tried the obvious thing first and rejected it with data**: a single combined alternation regex was *not* faster (5.3s vs 5.0s baseline) — CPython's regex engine walks alternation branches per position.
- **Shipped instead**: import-time extraction of *guaranteed literal keywords* from each KB pattern's parse tree (`re._parser`). A line that contains none of the keywords provably cannot match any guarded pattern, so it skips the ordered 75-regex loop entirely. Patterns with no provable literal (or only a <3-char one, which would fire on every line) stay in an always-checked list — **sound by construction, self-maintaining** as KB rules are added, and first-match-wins precedence is preserved exactly.

## Results (sample corpus ×20 = 292K events)
| | time | throughput |
|---|---|---|
| baseline | 5.05s | 1.2 MB/s, 58K ev/s |
| combined alternation (rejected) | 5.31s | 1.1 MB/s |
| **literal gate (this PR)** | **2.18s** | **2.7 MB/s, 134K ev/s** |

Classification output is **byte-identical** (asserted in the benchmark and pinned by a monkeypatch-based equivalence test). 82 keywords extracted, 2 patterns unguarded.

## Test plan
- [x] `ruff check` clean
- [x] 256/256 tests pass (4 new: gate-vs-full-loop equivalence on the whole sample corpus, structural invariants, guarded-match and no-match behavior)
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a literal keyword gate ahead of the classifier’s regex loop to significantly speed up log classification without changing results.

New Features:
- Add a parse-tree-based literal keyword gate that skips the full regex pattern loop for lines that cannot match any guarded pattern.

Enhancements:
- Derive guaranteed literals from regex parse trees at import time, maintaining an always-checked list for patterns without provable literals while preserving rule precedence.

Documentation:
- Document the classifier performance improvement and its guarantees in the changelog.
- Update README test count to reflect the expanded test suite.

Tests:
- Add tests to assert gate-versus-full-loop equivalence on the sample corpus, enforce structural invariants of the gate, and cover both matched and unmatched log lines.