### PR TITLE
feat: unknown-pattern template mining + custom rules; close sanitize/auth gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,31 @@
 
 # ── Server ────────────────────────────────────────────────────────────────────
 ANALYZER_PORT=6060
+# Bind address. Default 127.0.0.1 (localhost only). Set 0.0.0.0 to expose —
+# the server warns if you do that without an API token.
+#ANALYZER_HOST=127.0.0.1
+
+# ── Security ──────────────────────────────────────────────────────────────────
+# When set, every mutating/data API route requires the token, supplied as
+# either `X-API-Token: <token>` or `Authorization: Bearer <token>`.
+#AI_LOG_ANALYZER_API_TOKEN=
+# CORS allow-list for /api/* (comma-separated origins).
+#AI_LOG_ANALYZER_CORS_ORIGINS=http://localhost:6060,http://127.0.0.1:6060
+# Colon-separated roots POST /api/analyze {source:"file"} may read from.
+#AI_LOG_ANALYZER_FILE_ROOTS=~:/var/log
 
 # ── LLM provider ──────────────────────────────────────────────────────────────
+# ollama      : Ollama native API on :11434 (default provider)
 # local       : Docker Model Runner (TCP 12434 or auto-detected Unix socket)
 # claude      : Anthropic Claude first, fall back to local if Claude is unreachable
 # claude-only : Anthropic Claude only — never call local
-LLM_PROVIDER=local
+LLM_PROVIDER=ollama
 LLM_ENABLED=true
-LLM_TIMEOUT=60
+LLM_TIMEOUT=120
+
+# ── Ollama (native API) ───────────────────────────────────────────────────────
+#OLLAMA_URL=http://localhost:11434
+#OLLAMA_MODEL=qwen2.5-coder:latest
 
 # ── Local LLM (Docker Model Runner) ───────────────────────────────────────────
 MODEL_RUNNER_URL=http://localhost:12434
@@ -21,6 +38,12 @@ LLM_MODEL=ai/qwen3:latest
 # Get a key at https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+
+# ── Custom classification rules (optional) ────────────────────────────────────
+# JSON file with a list of {"pattern", "severity", "category", "description"}
+# objects. Loaded at startup; rules take precedence over the built-in KB.
+# Add more at runtime via POST /api/rules.
+#AI_LOG_ANALYZER_CUSTOM_RULES=~/.netlog-ai/rules.json
 
 # ── Alert webhooks (optional) ────────────────────────────────────────────────
 # When set, every analysis that finds events at/above the threshold severity

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ LLM_MODEL=ai/qwen3:latest
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 
+# ── Cross-run template memory (optional) ──────────────────────────────────────
+# Path to a JSON store remembering every mined template shape across runs.
+# When set, templates never seen in any prior run are flagged 🆕 in the
+# Unknown Patterns panel and counted as new_template_count in /api/analyze.
+#AI_LOG_ANALYZER_TEMPLATE_STORE=~/.cache/netlog-ai/templates.json
+
 # ── Custom classification rules (optional) ────────────────────────────────────
 # JSON file with a list of {"pattern", "severity", "category", "description"}
 # objects. Loaded at startup; rules take precedence over the built-in KB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,17 @@ loose semantic versioning.
   KB: a JSON rules file loaded at startup (`AI_LOG_ANALYZER_CUSTOM_RULES`) and
   a runtime API (`GET/POST /api/rules`). Custom rules are checked before the
   built-in patterns, so a known-noise event can be demoted or a site-specific
-  failure promoted. Suite 294 → 308 tests.
+  failure promoted.
+- **Cross-run template persistence** — set `AI_LOG_ANALYZER_TEMPLATE_STORE`
+  to a path and the miner remembers every template shape across runs
+  (FIFO-bounded JSON store, atomic writes, corrupt-file tolerant). Templates
+  never seen in *any* prior run are flagged `is_new` (🆕 in the UI panel,
+  `new_template_count` in the API) — the classic AIOps early-warning signal.
+- **Coverage wave for phases 0–12 leftovers** — `reports.py` (MD/CSV/HTML
+  exporters), `runbook.py` (Ansible/netmiko generation + command extraction),
+  `topology.py` (build/exports/finding overlay), and the previously untested
+  web routes `/api/report`, `/api/runbook`, `/api/topology`, plus the
+  validation paths of `/api/diff` and `/api/copilot`. Suite 294 → 325 tests.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to **netlog-ai** are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses
 loose semantic versioning.
 
+## [Unreleased]
+
+### Added
+
+- **Unknown-pattern template mining** (`patterns.py`) — every line the regex KB
+  can't match is mined into templates with a dependency-free Drain-style
+  streaming clusterer (variables masked as `<ip>/<mac>/<hex>/<if>/<n>/<ts>`,
+  similar shapes merged into `<*>` wildcards, LRU-bounded memory). The
+  analyzer surfaces the top templates — error-smelling shapes ranked first —
+  as `unknown_patterns` in `/api/analyze`, the MCP `analyze_logs` tool, and a
+  new **🔭 Unknown Patterns** panel in the UI. Novel failure modes no longer
+  vanish as `info` noise.
+- **Custom classification rules** — operators can extend/override the built-in
+  KB: a JSON rules file loaded at startup (`AI_LOG_ANALYZER_CUSTOM_RULES`) and
+  a runtime API (`GET/POST /api/rules`). Custom rules are checked before the
+  built-in patterns, so a known-noise event can be demoted or a site-specific
+  failure promoted. Suite 294 → 308 tests.
+
+### Security
+
+- **Log lines now pass the sanitize gate before LLM calls.** `deep_analyze()`
+  sent raw sample log lines (and severity-promoted raw descriptions) to the
+  LLM unsanitized — configs were always scrubbed but logs were not,
+  contradicting the sanitize-before-LLM guarantee. Both are now scrubbed, as
+  is the executive-summary item list.
+- **`/api/sources/<id>/test` and `/api/sources/<id>/fetch` now require the API
+  token** — they were the only POST data routes missing the auth gate.
+- **`Authorization: Bearer <token>` accepted** everywhere `X-API-Token` is
+  (the README documented Bearer; the code only accepted the custom header).
+
+### Fixed
+
+- **MCP server finds bundled sites on pip installs** — `list_sites` /
+  `analyze_site` resolved only the repo-root `sites/` symlink and returned
+  empty from a `pip install netlog-ai[mcp]` wheel; now uses the same
+  env-override → packaged-data → repo-root resolution as the web app.
+- **`/api/optimize/site` no longer mislabels device platforms on mixed-vendor
+  sites** — it stamped every device with the manifest-level vendor string
+  (e.g. `multi (Nokia SRL + Arista cEOS + FRR)`); it now uses the shared
+  loader that keeps per-device `platform`.
+- **Syslog connector `fetch()` is idempotent** — it used to drain the ring
+  buffer, so a correlate → triage sequence on the same source saw zero events
+  on the second call. It now snapshots; the deque's `maxlen` bounds memory.
+- **Default Ollama model corrected** to `qwen2.5-coder:latest` (was
+  `gemma4:latest`, which doesn't exist, breaking the out-of-box default
+  provider).
+- Env-configured sources no longer leak `verify_tls`/`timeout_seconds` into
+  `extra`; `.env.example` and README now document the real security env vars
+  (`AI_LOG_ANALYZER_API_TOKEN`, `AI_LOG_ANALYZER_CORS_ORIGINS`,
+  `ANALYZER_HOST`, `AI_LOG_ANALYZER_FILE_ROOTS`) and the `ollama` provider.
+
 ## [0.3.1] - 2026-06-10
 
 - UI header version badge is now populated live from `/api/health` (the 0.3.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > **Network logs in. Ranked actions out.** A local, dark-themed dashboard that classifies syslog events from any vendor (Junos, Arista EOS, FRR), builds a prioritized action list, and lets an LLM write the root-cause analysis with copy-pastable CLI fixes.
 
-[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-308%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
+[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-325%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -67,7 +67,7 @@ Tools exposed: `list_sources`, `add_source`, `fetch_logs`, `search_logs`,
 | 🔗 **Cross-source correlation** | **Device tab** → *Correlate Sources*: scans every registered source and tags each host `confirmed` (flagged by ≥ 2 sources) or `suspected` (1) in a sortable, severity-coded table |
 | 🔬 **Per-device triage** | **Device tab** → *Triage Device*: one host's verdict + 0–100 health score, severity histogram, top processes, and deduped error patterns in a single panel |
 | 🔎 **Classify** | 50+ regex patterns across Junos, EOS, FRR, IOS, RFC-3164/5424 — plus your own rules via `AI_LOG_ANALYZER_CUSTOM_RULES` / `POST /api/rules` |
-| 🔭 **Unknown patterns** | Lines no rule matched are template-mined (Drain-style, zero deps): variables masked, shapes clustered, error-smelling templates ranked first — novel failure modes surface instead of vanishing as `info` noise |
+| 🔭 **Unknown patterns** | Lines no rule matched are template-mined (Drain-style, zero deps): variables masked, shapes clustered, error-smelling templates ranked first — novel failure modes surface instead of vanishing as `info` noise. Set `AI_LOG_ANALYZER_TEMPLATE_STORE` for cross-run memory: shapes never seen in any prior run get flagged 🆕 |
 | 🧭 **Prioritize** | Deduped action items, ranked by severity × count, recovery events excluded |
 | 🧠 **Deep analyze** | Top-N items get an LLM-written root-cause + risk + remediation playbook |
 | 🛡️ **Sanitize-first** | Every config/log payload is scrubbed (`$6$`, `$9$`, SSH keys, SNMP, RADIUS, public IPs) before LLM call |
@@ -398,7 +398,7 @@ src/ai_log_analyzer/
 
 ## Tested & accessible
 
-- **308 unit + integration tests** (pytest)
+- **325 unit + integration tests** (pytest)
 - Frontend audited across 8 review rounds:
   - WCAG-AA: `:focus-visible` rings, `aria-live` regions, `role=tablist/tab/tabpanel`, skip-to-main link, `prefers-reduced-motion` fallback
   - Responsive ≤ 1100px, PWA-ready (`theme-color`, `mobile-web-app-capable`, SVG favicon)
@@ -415,7 +415,7 @@ src/ai_log_analyzer/
 - [ ] Snapshot / replay analysis runs for regression testing
 - [x] Custom classification rules — JSON file (`AI_LOG_ANALYZER_CUSTOM_RULES`) + runtime `POST /api/rules`; UI editor still open
 - [x] Unknown-pattern template mining — Drain-style clustering of unmatched lines, surfaced in UI/API/MCP
-- [ ] Cross-run template persistence ("first time this shape has ever been seen" alerting)
+- [x] Cross-run template persistence — `AI_LOG_ANALYZER_TEMPLATE_STORE` flags never-before-seen shapes (🆕)
 - [ ] Per-template volume anomaly detection (sudden rate spike/drop per device)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > **Network logs in. Ranked actions out.** A local, dark-themed dashboard that classifies syslog events from any vendor (Junos, Arista EOS, FRR), builds a prioritized action list, and lets an LLM write the root-cause analysis with copy-pastable CLI fixes.
 
-[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-294%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
+[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-308%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -66,7 +66,8 @@ Tools exposed: `list_sources`, `add_source`, `fetch_logs`, `search_logs`,
 | 🤖 **MCP server mode** | Claude Code / Cursor / Continue can call the analyzer directly as agent tools |
 | 🔗 **Cross-source correlation** | **Device tab** → *Correlate Sources*: scans every registered source and tags each host `confirmed` (flagged by ≥ 2 sources) or `suspected` (1) in a sortable, severity-coded table |
 | 🔬 **Per-device triage** | **Device tab** → *Triage Device*: one host's verdict + 0–100 health score, severity histogram, top processes, and deduped error patterns in a single panel |
-| 🔎 **Classify** | 50+ regex patterns across Junos, EOS, FRR, IOS, RFC-3164/5424 |
+| 🔎 **Classify** | 50+ regex patterns across Junos, EOS, FRR, IOS, RFC-3164/5424 — plus your own rules via `AI_LOG_ANALYZER_CUSTOM_RULES` / `POST /api/rules` |
+| 🔭 **Unknown patterns** | Lines no rule matched are template-mined (Drain-style, zero deps): variables masked, shapes clustered, error-smelling templates ranked first — novel failure modes surface instead of vanishing as `info` noise |
 | 🧭 **Prioritize** | Deduped action items, ranked by severity × count, recovery events excluded |
 | 🧠 **Deep analyze** | Top-N items get an LLM-written root-cause + risk + remediation playbook |
 | 🛡️ **Sanitize-first** | Every config/log payload is scrubbed (`$6$`, `$9$`, SSH keys, SNMP, RADIUS, public IPs) before LLM call |
@@ -111,10 +112,11 @@ pytest --cov=src --cov-report=term-missing
 
 ## Configure the LLM
 
-Three providers, switchable at runtime from the UI dropdown — or via env / API:
+Four providers, switchable at runtime from the UI dropdown — or via env / API:
 
 | Mode          | Order |
 |---------------|-------|
+| `ollama`      | Ollama native API on `:11434` (default; `OLLAMA_URL` / `OLLAMA_MODEL`) |
 | `local`       | Local Docker Model Runner → falls back to Claude if `ANTHROPIC_API_KEY` is set |
 | `claude`      | Claude first → falls back to local |
 | `claude-only` | Claude only, no fallback |
@@ -315,7 +317,8 @@ flowchart TB
 
 ```
 src/ai_log_analyzer/
-  classifier.py        50+ regex patterns + severity/category lookup
+  classifier.py        50+ regex patterns + severity/category lookup + custom rules
+  patterns.py          Drain-lite template miner for lines no rule matched
   kb.py                Rule-based deep-analysis KB (fallback when LLM is off)
   llm.py               Docker Model Runner (TCP + UDS) + Anthropic Claude
   analyzer.py          End-to-end pipeline: classify → actions → score → summary
@@ -346,7 +349,9 @@ src/ai_log_analyzer/
 | `POST` | `/api/llm/toggle` | `{"enabled": true\|false}` |
 | `GET`  | `/api/lab/containers` | Running FRR-lab container names |
 | `GET`  | `/api/sites` | List bundled site bundles |
-| `POST` | `/api/analyze` | Full pipeline — see request shapes below |
+| `POST` | `/api/analyze` | Full pipeline — see request shapes below (response includes `unknown_patterns`: mined templates of unmatched lines) |
+| `GET`  | `/api/rules` | Built-in rule count + registered custom classification rules |
+| `POST` | `/api/rules` | Add custom rules at runtime — `{"rules": [{"pattern", "severity", "category", "description"}]}` |
 | `POST` | `/api/optimize` | Device-level config audit + patches |
 | `POST` | `/api/optimize/site` | Cross-device site analysis |
 | `POST` | `/api/optimize/site-wide/<id>` | Strategic maturity scoring + phased roadmap |
@@ -385,14 +390,15 @@ src/ai_log_analyzer/
   - SNMP communities, RADIUS / TACACS+ keys
   - IPsec pre-shared keys
   - Public IPv4 addresses (mapped to RFC-5737 doc prefixes for the LLM context)
-- **Localhost bind by default** — set `ANALYZER_HOST=0.0.0.0` to expose; the server warns if you bind publicly without an `API_TOKEN`.
-- **API-token gate** — set `API_TOKEN=...` to require `Authorization: Bearer ...` on every POST.
-- **CORS allow-list** — `ANALYZER_CORS_ORIGINS=https://a.com,https://b.com`.
+- **Localhost bind by default** — set `ANALYZER_HOST=0.0.0.0` to expose; the server warns if you bind publicly without an API token.
+- **API-token gate** — set `AI_LOG_ANALYZER_API_TOKEN=...` to require the token on every POST, supplied as either `X-API-Token: <token>` or `Authorization: Bearer <token>`.
+- **CORS allow-list** — `AI_LOG_ANALYZER_CORS_ORIGINS=https://a.com,https://b.com`.
+- **File-ingest confinement** — `AI_LOG_ANALYZER_FILE_ROOTS=~:/var/log` bounds what `{source:"file"}` may read.
 - **No telemetry** — outbound calls go only to (a) the LLM provider you select and (b) the local Docker socket if you analyze FRR-lab containers.
 
 ## Tested & accessible
 
-- **294 unit + integration tests** (pytest)
+- **308 unit + integration tests** (pytest)
 - Frontend audited across 8 review rounds:
   - WCAG-AA: `:focus-visible` rings, `aria-live` regions, `role=tablist/tab/tabpanel`, skip-to-main link, `prefers-reduced-motion` fallback
   - Responsive ≤ 1100px, PWA-ready (`theme-color`, `mobile-web-app-capable`, SVG favicon)
@@ -407,7 +413,10 @@ src/ai_log_analyzer/
 - [x] Slack / generic-JSON alert webhooks per severity threshold (`AI_LOG_ANALYZER_WEBHOOK_URL` — see `.env.example`)
 - [ ] More vendor adapters (Nokia SR Linux, Cisco IOS-XE, Cumulus NCLU)
 - [ ] Snapshot / replay analysis runs for regression testing
-- [ ] Custom rule editor in the UI
+- [x] Custom classification rules — JSON file (`AI_LOG_ANALYZER_CUSTOM_RULES`) + runtime `POST /api/rules`; UI editor still open
+- [x] Unknown-pattern template mining — Drain-style clustering of unmatched lines, surfaced in UI/API/MCP
+- [ ] Cross-run template persistence ("first time this shape has ever been seen" alerting)
+- [ ] Per-template volume anomaly detection (sudden rate spike/drop per device)
 
 ## Contributing
 

--- a/src/ai_log_analyzer/adapters/tfsm_auto.py
+++ b/src/ai_log_analyzer/adapters/tfsm_auto.py
@@ -37,9 +37,11 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 # Public-facing URL of the upstream template database. Pinned to the main branch.
-# If upstream restructures, change this constant or set TFSM_DB_PATH locally.
-_UPSTREAM_DB_URL = (
-    "https://github.com/scottpeterman/tfsm_fire/raw/main/tfire/tfsm_templates.db"
+# Upstream has restructured before (the raw URL 404s when it does) — override
+# with TFSM_DB_URL to point at a mirror, or TFSM_DB_PATH at a local copy.
+_UPSTREAM_DB_URL = os.environ.get(
+    "TFSM_DB_URL",
+    "https://github.com/scottpeterman/tfsm_fire/raw/main/tfire/tfsm_templates.db",
 )
 _DEFAULT_DB_PATH = Path(
     os.environ.get(

--- a/src/ai_log_analyzer/analyzer.py
+++ b/src/ai_log_analyzer/analyzer.py
@@ -15,7 +15,7 @@ from ai_log_analyzer.classifier import (
     LogEvent,
     iter_classify,
 )
-from ai_log_analyzer.patterns import TemplateMiner
+from ai_log_analyzer.patterns import TemplateMiner, apply_template_store
 from ai_log_analyzer.sanitize import sanitize
 
 
@@ -568,6 +568,9 @@ def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3
     top_events, sev_counts, cat_counts, groups, by_host, miner = _aggregate_stream(
         iter_classify(events)
     )
+    # Opt-in cross-run persistence: flags templates never seen in ANY prior
+    # run (AI_LOG_ANALYZER_TEMPLATE_STORE) — the classic AIOps early-warning.
+    apply_template_store(miner)
 
     effective_llm = use_llm and llm.is_enabled()
     action_items = _finalize_action_items(

--- a/src/ai_log_analyzer/analyzer.py
+++ b/src/ai_log_analyzer/analyzer.py
@@ -15,6 +15,7 @@ from ai_log_analyzer.classifier import (
     LogEvent,
     iter_classify,
 )
+from ai_log_analyzer.patterns import TemplateMiner
 from ai_log_analyzer.sanitize import sanitize
 
 
@@ -89,6 +90,7 @@ class AnalysisResult:
     executive_summary: list[str]
     llm_powered: bool
     generated_at: str
+    unknown_patterns: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -103,6 +105,7 @@ class AnalysisResult:
             "executive_summary": self.executive_summary,
             "llm_powered": self.llm_powered,
             "generated_at": self.generated_at,
+            "unknown_patterns": self.unknown_patterns,
         }
 
 
@@ -209,11 +212,19 @@ def deep_analyze(
 
     llm_result: dict | None = None
     if not skip_llm:
-        samples = "\n".join(f"  - {m}" for m in sample_messages[:5]) or "  (no samples)"
+        # CRITICAL: raw log lines can carry secrets (auth failures echo
+        # usernames, SNMP traps echo communities, RADIUS/TACACS lines echo
+        # server keys). Same sanitize gate as the config paths — nothing
+        # reaches an external LLM unscrubbed.
+        safe_samples = [sanitize(m, mask_pii=True)[0] for m in sample_messages[:5]]
+        samples = "\n".join(f"  - {m}" for m in safe_samples) or "  (no samples)"
+        # Descriptions are usually KB constants, but severity-promoted events
+        # (raw crit/emerg/alert with no KB match) carry a raw message snippet.
+        safe_description, _ = sanitize(description, mask_pii=True)
         user_prompt = (
             f"INCIDENT CONTEXT\n"
             f"Category: {category}\n"
-            f"Description: {description}\n"
+            f"Description: {safe_description}\n"
             f"Occurrences: {count}\n"
             f"Affected devices ({len(devices)}): {', '.join(devices[:5]) if devices else 'unknown'}\n"
             f"Platform hint: {platform_hint or 'mixed (frr/junos/eos)'}\n"
@@ -462,8 +473,8 @@ def _executive_summary(
             "- Match hostnames verbatim — no abbreviations, no shortenings."
         )
         top = [
-            f"{a.severity.upper()} | {a.description} ({a.count}× on "
-            f"{', '.join(a.devices[:5]) if a.devices else 'unknown'})"
+            f"{a.severity.upper()} | {sanitize(a.description, mask_pii=True)[0]} "
+            f"({a.count}× on {', '.join(a.devices[:5]) if a.devices else 'unknown'})"
             for a in items[:5]
         ]
         user_prompt = (
@@ -504,26 +515,31 @@ def _executive_summary(
 
 def _aggregate_stream(
     classified: Iterable[ClassifiedEvent], top_k: int = 300,
-) -> tuple[list[ClassifiedEvent], dict[str, int], dict[str, int], dict, dict]:
+) -> tuple[list[ClassifiedEvent], dict[str, int], dict[str, int], dict, dict, TemplateMiner]:
     """Single bounded pass over a classified stream.
 
-    Memory is O(top_k + KB rules + devices) regardless of input size — this
-    is what lets analyze() handle multi-GB syslog without materializing it.
-    Per-severity heaps keyed on (timestamp, -seq) keep the newest top_k
-    events of each severity; finalization reproduces classify_events()'
-    ordering exactly (severity rank, then timestamp desc, then arrival).
+    Memory is O(top_k + KB rules + devices + template clusters) regardless of
+    input size — this is what lets analyze() handle multi-GB syslog without
+    materializing it. Per-severity heaps keyed on (timestamp, -seq) keep the
+    newest top_k events of each severity; finalization reproduces
+    classify_events()' ordering exactly (severity rank, then timestamp desc,
+    then arrival). Events no KB rule matched are additionally mined into
+    templates so novel message shapes surface instead of vanishing as noise.
     """
     sev_counts: dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
     cat_counts: dict[str, int] = {}
     buckets: dict[str, list] = {sev: [] for sev in SEV_ORDER}
     groups: dict[tuple[str, str], dict] = {}
     by_host: dict[str, dict] = {}
+    miner = TemplateMiner()
 
     for seq, e in enumerate(classified):
         sev_counts[e.severity] = sev_counts.get(e.severity, 0) + 1
         cat_counts[e.category] = cat_counts.get(e.category, 0) + 1
         _group_actionable(e, groups, seq)
         _count_device(e, by_host)
+        if e.category == "other" and e.message:
+            miner.add(e.message, e.hostname)
         heap = buckets.setdefault(e.severity, [])
         entry = (e.timestamp, -seq, e)
         if len(heap) < top_k:
@@ -538,7 +554,7 @@ def _aggregate_stream(
         )
         if len(top_events) >= top_k:
             break
-    return top_events[:top_k], sev_counts, cat_counts, groups, by_host
+    return top_events[:top_k], sev_counts, cat_counts, groups, by_host, miner
 
 
 def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3) -> AnalysisResult:
@@ -549,7 +565,7 @@ def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3
     event list. Thread-safe: never mutates global llm state. `use_llm=False`
     is enforced by forcing `llm_top_n=0` and disabling the LLM exec summary.
     """
-    top_events, sev_counts, cat_counts, groups, by_host = _aggregate_stream(
+    top_events, sev_counts, cat_counts, groups, by_host, miner = _aggregate_stream(
         iter_classify(events)
     )
 
@@ -575,6 +591,7 @@ def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3
         executive_summary=summary,
         llm_powered=any_llm,
         generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        unknown_patterns=miner.to_dict(top_n=10),
     )
 
 

--- a/src/ai_log_analyzer/classifier.py
+++ b/src/ai_log_analyzer/classifier.py
@@ -5,6 +5,7 @@ Works on any normalized event regardless of source (Kibana, FRR docker logs, raw
 """
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass, field
 from typing import Iterable, Iterator
@@ -162,6 +163,71 @@ _KEYWORDS = tuple(sorted(
     if not any(other != k and other in k for other in _kw)
 ))
 
+# ── Custom user rules ────────────────────────────────────────────────────
+# Loaded from a JSON file (env AI_LOG_ANALYZER_CUSTOM_RULES or add_custom_rules()).
+# Custom rules are checked BEFORE the built-in KB so operators can override
+# any built-in verdict. They bypass the literal gate — rule counts are small,
+# so the extra scans are negligible.
+_CUSTOM_RULES: list[tuple[re.Pattern[str], str, str, str]] = []
+
+
+def add_custom_rules(rules: list[dict]) -> tuple[int, list[str]]:
+    """Register user-defined classification rules at runtime.
+
+    Each rule: {"pattern": regex, "severity": critical|high|medium|low|info,
+    "category": str, "description": str}. Returns (added_count, errors);
+    invalid rules are skipped, never fatal.
+    """
+    added, errors = 0, []
+    for i, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            errors.append(f"rule {i}: not an object")
+            continue
+        pattern = rule.get("pattern", "")
+        severity = str(rule.get("severity", "")).lower()
+        category = str(rule.get("category", "custom")) or "custom"
+        description = str(rule.get("description", "")) or "Custom rule match"
+        if severity not in SEV_ORDER:
+            errors.append(f"rule {i}: invalid severity {severity!r}")
+            continue
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as exc:
+            errors.append(f"rule {i}: bad regex: {exc}")
+            continue
+        _CUSTOM_RULES.append((compiled, severity, category, description))
+        added += 1
+    return added, errors
+
+
+def load_custom_rules_file(path: str) -> tuple[int, list[str]]:
+    """Load custom rules from a JSON file: a list of rule objects."""
+    import json
+    from pathlib import Path
+    p = Path(path).expanduser()
+    if not p.is_file():
+        return 0, [f"custom rules file not found: {p}"]
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return 0, [f"custom rules file unreadable: {exc}"]
+    if not isinstance(data, list):
+        return 0, ["custom rules file must contain a JSON list"]
+    return add_custom_rules(data)
+
+
+def custom_rules() -> list[dict]:
+    """JSON-ready view of the currently registered custom rules."""
+    return [
+        {"pattern": p.pattern, "severity": s, "category": c, "description": d}
+        for (p, s, c, d) in _CUSTOM_RULES
+    ]
+
+
+_rules_path = os.environ.get("AI_LOG_ANALYZER_CUSTOM_RULES", "")
+if _rules_path:
+    load_custom_rules_file(_rules_path)
+
 # ANSI/VT100 terminal escape sequences — systemd, journald, FRR vtysh, and
 # any source piping colored output leaks these into the message field.
 # Pattern covers CSI (\x1b[...m), OSC (\x1b]...\x07), and SGR-style codes.
@@ -259,16 +325,23 @@ def iter_classify(events: Iterable[LogEvent]) -> Iterator[ClassifiedEvent]:
         combined = f"{ev.appname} {clean_message}".lower()
         sev, cat, desc = "info", "other", ""
 
-        # Literal gate: no keyword → only the unproven patterns can possibly
-        # match (their relative order is preserved, so precedence holds).
-        if any(k in combined for k in _KEYWORDS):
-            candidates = _COMPILED
-        else:
-            candidates = _UNGUARDED
-        for pattern, p_sev, p_cat, p_desc in candidates:
+        # Custom user rules take precedence over the built-in KB.
+        for pattern, p_sev, p_cat, p_desc in _CUSTOM_RULES:
             if pattern.search(combined):
                 sev, cat, desc = p_sev, p_cat, p_desc
                 break
+
+        if not desc:
+            # Literal gate: no keyword → only the unproven patterns can possibly
+            # match (their relative order is preserved, so precedence holds).
+            if any(k in combined for k in _KEYWORDS):
+                candidates = _COMPILED
+            else:
+                candidates = _UNGUARDED
+            for pattern, p_sev, p_cat, p_desc in candidates:
+                if pattern.search(combined):
+                    sev, cat, desc = p_sev, p_cat, p_desc
+                    break
 
         if not desc:
             snippet = clean_message[:120].strip() or ev.appname or "General log message"

--- a/src/ai_log_analyzer/llm.py
+++ b/src/ai_log_analyzer/llm.py
@@ -1,4 +1,4 @@
-"""Pluggable LLM client with three providers:
+"""Pluggable LLM client with four providers:
 
   - "ollama"      : Ollama native API (gemma3 / qwen2.5-coder / llama3.2) — preferred local
   - "local"       : Docker Model Runner (OpenAI-compatible) via TCP or Unix socket

--- a/src/ai_log_analyzer/llm.py
+++ b/src/ai_log_analyzer/llm.py
@@ -45,7 +45,7 @@ _state: dict[str, object] = {
     "enabled":            os.environ.get("LLM_ENABLED", "true").lower() == "true",
     # Ollama (native API)
     "ollama_url":         os.environ.get("OLLAMA_URL", "http://localhost:11434"),
-    "ollama_model":       os.environ.get("OLLAMA_MODEL", "gemma4:latest"),
+    "ollama_model":       os.environ.get("OLLAMA_MODEL", "qwen2.5-coder:latest"),
     # Docker Model Runner (OpenAI-compatible)
     "local_url":          os.environ.get("MODEL_RUNNER_URL", "http://localhost:12434"),
     "local_model":        os.environ.get("LLM_MODEL", "ai/qwen3:latest"),
@@ -152,7 +152,7 @@ def query(system_prompt: str, user_prompt: str, max_tokens: int = 800) -> Option
 # ── Ollama native API ────────────────────────────────────────────────────────
 
 def _query_ollama(system_prompt: str, user_prompt: str, max_tokens: int) -> Optional[str]:
-    """Ollama native /api/chat — supports `think:false` for gemma4/qwen3."""
+    """Ollama native /api/chat — supports `think:false` for thinking models (qwen3 etc.)."""
     url = f"{str(_state['ollama_url']).rstrip('/')}/api/chat"
     payload = {
         "model": _state["ollama_model"],

--- a/src/ai_log_analyzer/mcp_server/server.py
+++ b/src/ai_log_analyzer/mcp_server/server.py
@@ -35,7 +35,21 @@ from ai_log_analyzer.sources.manager import manager as source_manager
 
 log = logging.getLogger(__name__)
 
-_SITES_DIR = Path(__file__).resolve().parents[3] / "sites"
+def _resolve_sites_dir() -> Path:
+    """Same resolution order as the web app: env override → packaged data
+    (present in pip/Docker installs) → legacy repo-root layout. The old
+    repo-root-only lookup made list_sites/analyze_site return empty on any
+    `pip install netlog-ai[mcp]` wheel."""
+    override = os.environ.get("AI_LOG_ANALYZER_SITES_DIR", "")
+    if override:
+        return Path(override).expanduser()
+    packaged = Path(__file__).resolve().parents[1] / "data" / "sites"
+    if packaged.is_dir():
+        return packaged
+    return Path(__file__).resolve().parents[3] / "sites"
+
+
+_SITES_DIR = _resolve_sites_dir()
 
 
 def _build_server():
@@ -277,7 +291,7 @@ def _build_server():
         cross-device findings (BGP, OSPF, MTU, BFD, LLDP gaps + topology hints).
 
         Note: LLM usage is governed by the server-side LLM toggle, not a per-call
-        parameter — same behaviour as the web UI's /api/site/analyze endpoint.
+        parameter — same behaviour as the web UI's /api/optimize/site endpoint.
         """
         from ai_log_analyzer.analyzer import analyze_site as _analyze_site
         safe_id = re.sub(r"[^a-zA-Z0-9_\-]", "", site_id)

--- a/src/ai_log_analyzer/patterns.py
+++ b/src/ai_log_analyzer/patterns.py
@@ -21,9 +21,15 @@ analyze()'s single streaming pass at any input size.
 """
 from __future__ import annotations
 
+import json
+import logging
+import os
 import re
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Masking rules applied before tokenization, most specific first.
 # Every mask becomes a fixed token so it can't split template shapes.
@@ -72,6 +78,7 @@ class TemplateCluster:
     hosts: set[str] = field(default_factory=set)
     sample: str = ""              # first raw (masked) example, for the UI
     severity_hint: str = "info"   # promoted if the shape smells like an error
+    is_new: bool = False          # never seen in any prior run (needs a store)
 
     @property
     def template(self) -> str:
@@ -85,6 +92,7 @@ class TemplateCluster:
             "host_count": len(self.hosts),
             "sample": self.sample,
             "severity_hint": self.severity_hint,
+            "is_new": self.is_new,
         }
 
 
@@ -174,10 +182,11 @@ class TemplateMiner:
         return len(self._clusters)
 
     def top(self, n: int = 10, errorish_first: bool = True) -> list[TemplateCluster]:
-        """Highest-signal clusters: error-smelling shapes first, then by volume."""
+        """Highest-signal clusters: error-smelling shapes first, never-seen
+        shapes next within each band, then by volume."""
         clusters = list(self._clusters.values())
         if errorish_first:
-            clusters.sort(key=lambda c: (c.severity_hint == "info", -c.count))
+            clusters.sort(key=lambda c: (c.severity_hint == "info", not c.is_new, -c.count))
         else:
             clusters.sort(key=lambda c: -c.count)
         return clusters[:n]
@@ -188,5 +197,80 @@ class TemplateMiner:
         return {
             "total_unclassified": sum(c.count for c in self._clusters.values()),
             "template_count": self.cluster_count,
+            "new_template_count": sum(1 for c in self._clusters.values() if c.is_new),
             "top_templates": [c.to_dict() for c in top],
         }
+
+
+class TemplateStore:
+    """On-disk memory of every template shape seen in prior runs.
+
+    Backs the highest-signal AIOps event — "this message shape has NEVER been
+    seen before" — across analysis runs. The store is a flat JSON list of
+    template strings, FIFO-bounded so it can't grow without limit. Wildcard
+    merging can rename a template between runs, so matching is exact-string
+    and deliberately conservative: a renamed shape reports as new once, then
+    settles.
+    """
+
+    def __init__(self, path: str | Path, max_entries: int = 20_000) -> None:
+        self.path = Path(path).expanduser()
+        self.max_entries = max_entries
+        self._templates: OrderedDict[str, None] = OrderedDict()
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.is_file():
+            return
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("template store unreadable (%s) — starting fresh", exc)
+            return
+        if isinstance(data, list):
+            for t in data[-self.max_entries:]:
+                if isinstance(t, str):
+                    self._templates[t] = None
+
+    def __contains__(self, template: str) -> bool:
+        return template in self._templates
+
+    def __len__(self) -> int:
+        return len(self._templates)
+
+    def mark_and_update(self, miner: TemplateMiner) -> int:
+        """Flag never-before-seen clusters as `is_new`, absorb this run's
+        templates into the store, and return the new-template count."""
+        new_count = 0
+        for cluster in miner._clusters.values():
+            t = cluster.template
+            if t not in self._templates:
+                cluster.is_new = True
+                new_count += 1
+            self._templates[t] = None
+        while len(self._templates) > self.max_entries:
+            self._templates.popitem(last=False)
+        return new_count
+
+    def save(self) -> None:
+        """Persist atomically; failures are logged, never raised — a broken
+        store must not break an analysis run."""
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+            tmp.write_text(json.dumps(list(self._templates)), encoding="utf-8")
+            tmp.replace(self.path)
+        except OSError as exc:
+            logger.warning("could not persist template store to %s: %s", self.path, exc)
+
+
+def apply_template_store(miner: TemplateMiner) -> None:
+    """Opt-in cross-run persistence: when AI_LOG_ANALYZER_TEMPLATE_STORE
+    names a path, mark this run's never-seen-before templates and update the
+    store. No env var → no-op (single-run behaviour unchanged)."""
+    store_path = os.environ.get("AI_LOG_ANALYZER_TEMPLATE_STORE", "")
+    if not store_path or miner.cluster_count == 0:
+        return
+    store = TemplateStore(store_path)
+    store.mark_and_update(miner)
+    store.save()

--- a/src/ai_log_analyzer/patterns.py
+++ b/src/ai_log_analyzer/patterns.py
@@ -1,0 +1,192 @@
+"""Streaming template miner for *unclassified* log events (Drain-lite).
+
+Every event the regex KB can't match is silently classified `info`/`other`
+and vanishes from the action list — yet "a message shape we've never seen
+before" is one of the strongest early-warning signals in network operations
+(new error paths show up as new templates before they show up as outages).
+
+This module mines those unmatched lines into templates with zero external
+dependencies, so the analyzer can surface a ranked "unknown patterns" panel
+next to the KB-classified action items:
+
+  1. **Mask** variable parts (IPs, MACs, hex, numbers, interface names) so
+     `bgp peer 10.0.0.1 reset` and `bgp peer 10.0.0.9 reset` share a shape.
+  2. **Cluster** masked token streams with a fixed-depth parse tree keyed by
+     (token count, first token) and a similarity threshold — the same idea
+     as the Drain algorithm, trimmed to what syslog needs.
+  3. **Merge** diverging tokens into `<*>` wildcards as a cluster grows.
+
+Memory is bounded by `max_clusters` (LRU eviction), so it is safe inside
+analyze()'s single streaming pass at any input size.
+"""
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from dataclasses import dataclass, field
+
+# Masking rules applied before tokenization, most specific first.
+# Every mask becomes a fixed token so it can't split template shapes.
+_MASKS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}(?:/\d{1,2})?(?::\d+)?\b"), "<ip>"),
+    (re.compile(r"\b(?:[0-9a-f]{2}[:.-]){5}[0-9a-f]{2}\b", re.I), "<mac>"),
+    (re.compile(r"\b(?:[0-9a-f]{4}\.){2}[0-9a-f]{4}\b", re.I), "<mac>"),
+    (re.compile(r"\b[0-9a-f]{2}(?::[0-9a-f]{2}){3,}\b", re.I), "<hex>"),
+    (re.compile(r"\b0x[0-9a-f]+\b", re.I), "<hex>"),
+    # interface names: ge-0/0/1.0, xe-1/2/3, et-0/0/0, Ethernet49/1, eth1, ae0.100
+    (re.compile(r"\b(?:[gxem]t?e|et|ae|irb|lo|vlan|fxp|em|mge)-?\d+(?:[/.:]\d+)*\b", re.I), "<if>"),
+    (re.compile(r"\b(?:hundredgige|fortygige|twentyfivegige|tengige|gigabitethernet|fastethernet|ethernet|port-channel|tunnel|loopback|management)\d+(?:[/.:]\d+)*\b", re.I), "<if>"),
+    # ISO / syslog timestamps embedded mid-message
+    (re.compile(r"\b\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:z|[+-]\d{2}:?\d{2})?\b", re.I), "<ts>"),
+    (re.compile(r"\b\d{2}:\d{2}:\d{2}(?:\.\d+)?\b"), "<ts>"),
+    # any remaining integers / decimals (counters, PIDs, ports, durations)
+    (re.compile(r"(?<![\w.])\d+(?:\.\d+)?(?![\w.])"), "<n>"),
+]
+
+_WILDCARD = "<*>"
+
+
+def mask_message(message: str) -> str:
+    """Replace variable fields (IPs, MACs, hex, numbers, interfaces) with tokens."""
+    out = message
+    for pattern, token in _MASKS:
+        out = pattern.sub(token, out)
+    return out
+
+
+def _similarity(a: list[str], b: list[str]) -> float:
+    """Positional token similarity of two equal-length token lists (0..1)."""
+    if not a:
+        return 1.0
+    same = sum(1 for x, y in zip(a, b) if x == y or x == _WILDCARD or y == _WILDCARD)
+    return same / len(a)
+
+
+@dataclass
+class TemplateCluster:
+    """One mined template with its live statistics."""
+    cluster_id: int
+    tokens: list[str]
+    group_key: tuple[int, str] = (0, "")
+    count: int = 0
+    hosts: set[str] = field(default_factory=set)
+    sample: str = ""              # first raw (masked) example, for the UI
+    severity_hint: str = "info"   # promoted if the shape smells like an error
+
+    @property
+    def template(self) -> str:
+        return " ".join(self.tokens)
+
+    def to_dict(self) -> dict:
+        return {
+            "template": self.template,
+            "count": self.count,
+            "hosts": sorted(self.hosts)[:10],
+            "host_count": len(self.hosts),
+            "sample": self.sample,
+            "severity_hint": self.severity_hint,
+        }
+
+
+# Words that mark an unknown template as probably-bad even though no KB rule
+# matched it. Deliberately conservative: presence promotes the hint only.
+_ERRORISH_RE = re.compile(
+    r"\b(?:error|err|fail|failed|failure|crit|critical|fatal|panic|deny|denied|"
+    r"drop|dropped|timeout|unreachable|refused|invalid|corrupt|exceed|exceeded|"
+    r"mismatch|abort|aborted|lost|expired|violation)\b",
+    re.IGNORECASE,
+)
+
+
+class TemplateMiner:
+    """Fixed-depth streaming template miner (Drain-lite), bounded memory.
+
+    Clusters are grouped by (token_count, first_token); within a group a new
+    line joins the most similar cluster above `sim_threshold`, merging
+    diverging positions into `<*>`, otherwise it starts a new cluster.
+    """
+
+    def __init__(self, sim_threshold: float = 0.55, max_clusters: int = 512,
+                 max_tokens: int = 40) -> None:
+        self.sim_threshold = sim_threshold
+        self.max_clusters = max_clusters
+        self.max_tokens = max_tokens
+        self._clusters: OrderedDict[int, TemplateCluster] = OrderedDict()
+        self._groups: dict[tuple[int, str], list[int]] = {}
+        self._next_id = 1
+
+    def add(self, message: str, hostname: str = "") -> TemplateCluster:
+        """Feed one raw message; returns the cluster it joined or created."""
+        masked = mask_message(message.strip())
+        tokens = masked.split()
+        if len(tokens) > self.max_tokens:
+            tokens = tokens[: self.max_tokens]
+        # Group key: length + first token — wildcard first tokens bucket together.
+        first = tokens[0] if tokens else ""
+        if first.startswith("<"):
+            first = _WILDCARD
+        key = (len(tokens), first)
+
+        best: TemplateCluster | None = None
+        best_sim = 0.0
+        for cid in self._groups.get(key, ()):
+            cluster = self._clusters.get(cid)
+            if cluster is None:
+                continue
+            sim = _similarity(cluster.tokens, tokens)
+            if sim > best_sim:
+                best, best_sim = cluster, sim
+
+        if best is not None and best_sim >= self.sim_threshold:
+            # Merge diverging positions into wildcards.
+            best.tokens = [
+                t if t == u else _WILDCARD for t, u in zip(best.tokens, tokens)
+            ]
+            cluster = best
+        else:
+            cluster = TemplateCluster(
+                cluster_id=self._next_id, tokens=tokens, group_key=key,
+                sample=masked[:200],
+            )
+            self._next_id += 1
+            self._clusters[cluster.cluster_id] = cluster
+            self._groups.setdefault(key, []).append(cluster.cluster_id)
+            self._evict_if_needed()
+
+        cluster.count += 1
+        if hostname:
+            cluster.hosts.add(hostname)
+        if cluster.severity_hint == "info" and _ERRORISH_RE.search(masked):
+            cluster.severity_hint = "warning"
+        # LRU touch
+        self._clusters.move_to_end(cluster.cluster_id)
+        return cluster
+
+    def _evict_if_needed(self) -> None:
+        while len(self._clusters) > self.max_clusters:
+            old_id, old = self._clusters.popitem(last=False)
+            ids = self._groups.get(old.group_key)
+            if ids and old_id in ids:
+                ids.remove(old_id)
+
+    @property
+    def cluster_count(self) -> int:
+        return len(self._clusters)
+
+    def top(self, n: int = 10, errorish_first: bool = True) -> list[TemplateCluster]:
+        """Highest-signal clusters: error-smelling shapes first, then by volume."""
+        clusters = list(self._clusters.values())
+        if errorish_first:
+            clusters.sort(key=lambda c: (c.severity_hint == "info", -c.count))
+        else:
+            clusters.sort(key=lambda c: -c.count)
+        return clusters[:n]
+
+    def to_dict(self, top_n: int = 10) -> dict:
+        """JSON-ready summary for AnalysisResult / API / MCP."""
+        top = self.top(top_n)
+        return {
+            "total_unclassified": sum(c.count for c in self._clusters.values()),
+            "template_count": self.cluster_count,
+            "top_templates": [c.to_dict() for c in top],
+        }

--- a/src/ai_log_analyzer/sources/manager.py
+++ b/src/ai_log_analyzer/sources/manager.py
@@ -151,9 +151,9 @@ class SourceManager:
                 username=fields.pop("username", ""),
                 password=fields.pop("password", ""),
                 cookies=cookies,
+                verify_tls=fields.pop("verify_tls", "true").lower() != "false",
+                timeout_seconds=float(fields.pop("timeout_seconds", "30")),
                 extra={k: v for k, v in fields.items() if v},
-                verify_tls=fields.get("verify_tls", "true").lower() != "false",
-                timeout_seconds=float(fields.get("timeout_seconds", "30")),
             )
             try:
                 self.add(cfg)

--- a/src/ai_log_analyzer/sources/syslog.py
+++ b/src/ai_log_analyzer/sources/syslog.py
@@ -59,10 +59,12 @@ class SyslogListenerSource:
 
     def fetch(self, *, since_seconds: int = 3600, limit: int = 10_000,
               host_filter: str = "") -> Iterable[LogEvent]:
-        # Drain up to `limit` lines from the buffer (newest-last order preserved).
+        # Snapshot up to `limit` lines (newest-last order preserved) WITHOUT
+        # draining. Every other connector is idempotent; clearing here meant a
+        # correlate → triage sequence on the same source saw zero events on
+        # the second call. The deque's maxlen already bounds memory.
         with self._lock:
             lines = list(self._buffer)
-            self._buffer.clear()
         if limit and len(lines) > limit:
             lines = lines[-int(limit):]
         for ev in parse_lines(lines, default_host=host_filter or "syslog"):

--- a/src/ai_log_analyzer/web/app.py
+++ b/src/ai_log_analyzer/web/app.py
@@ -98,9 +98,20 @@ class BadCommand(ValueError):
     """Raised when /api/run receives a command we won't translate to argv."""
 
 
-def require_api_token(fn):
-    """Require X-API-Token header when AI_LOG_ANALYZER_API_TOKEN is set.
+def _token_supplied() -> str:
+    """The API token from the request, from either accepted header form."""
+    supplied = request.headers.get("X-API-Token", "")
+    if not supplied:
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            supplied = auth[len("Bearer "):].strip()
+    return supplied
 
+
+def require_api_token(fn):
+    """Require the API token when AI_LOG_ANALYZER_API_TOKEN is set.
+
+    Accepted as `X-API-Token: <token>` or `Authorization: Bearer <token>`.
     When the env var is empty (dev mode + bound to 127.0.0.1) this decorator
     is a no-op. Once set, every mutating route must present the token.
     """
@@ -108,8 +119,7 @@ def require_api_token(fn):
     def wrapper(*args, **kwargs):
         if not API_TOKEN:
             return fn(*args, **kwargs)
-        supplied = request.headers.get("X-API-Token", "")
-        if supplied != API_TOKEN:
+        if _token_supplied() != API_TOKEN:
             abort(401)
         return fn(*args, **kwargs)
     return wrapper
@@ -240,7 +250,7 @@ def create_app() -> Flask:
         # last_errors carries upstream HTTP error bodies — useful in the UI,
         # but on a token-protected deployment don't hand it to anonymous
         # callers. Dev mode (no token) keeps full output for the dashboard.
-        if API_TOKEN and request.headers.get("X-API-Token", "") != API_TOKEN:
+        if API_TOKEN and _token_supplied() != API_TOKEN:
             state = {k: v for k, v in state.items() if k != "last_errors"}
         return jsonify(state)
 
@@ -259,6 +269,36 @@ def create_app() -> Flask:
         body = request.get_json(silent=True) or {}
         enabled = bool(body.get("enabled", True))
         return jsonify({"ok": True, "enabled": llm.set_enabled(enabled)})
+
+    # ── Classification rules ──────────────────────────────────────────────
+    @app.route("/api/rules", methods=["GET"])
+    def api_rules_list():
+        """Built-in rule count + the operator's custom classification rules."""
+        from ai_log_analyzer import classifier as _clf
+        return jsonify({
+            "builtin_count": len(_clf._KB_PATTERNS),
+            "custom": _clf.custom_rules(),
+        })
+
+    @app.route("/api/rules", methods=["POST"])
+    @require_api_token
+    def api_rules_add():
+        """Register custom classification rules at runtime (non-persistent).
+
+        Body: {"rules": [{"pattern": "...", "severity": "high",
+                          "category": "...", "description": "..."}]}
+        Persist across restarts by putting the same list in a JSON file and
+        pointing AI_LOG_ANALYZER_CUSTOM_RULES at it.
+        """
+        from ai_log_analyzer import classifier as _clf
+        body = request.get_json(silent=True) or {}
+        rules = body.get("rules")
+        if not isinstance(rules, list) or not rules:
+            return jsonify({"error": "body must be {\"rules\": [...]} with ≥1 rule"}), 400
+        added, errors = _clf.add_custom_rules(rules)
+        status = 200 if added else 400
+        return jsonify({"added": added, "errors": errors,
+                        "custom_total": len(_clf.custom_rules())}), status
 
     # ── Inventory ─────────────────────────────────────────────────────────
     @app.route("/api/lab/containers", methods=["GET"])
@@ -561,26 +601,15 @@ def create_app() -> Flask:
         safe = "".join(c for c in site_id if c.isalnum() or c in "-_").lower()
         if safe != site_id.lower():
             return jsonify({"error": "invalid site id"}), 400
-        site_dir = SITES_DIR / safe
-        manifest_path = site_dir / "manifest.json"
-        if not manifest_path.is_file():
-            return jsonify({"error": f"site bundle not found: {safe}"}), 404
         if not llm.get_state()["enabled"]:
             return jsonify({"error": "LLM is disabled — site analysis needs LLM"}), 400
 
-        import json as _json
-        manifest = _json.loads(manifest_path.read_text(encoding="utf-8"))
-        devices: list[dict] = []
-        for d in manifest.get("devices", []):
-            fpath = site_dir / d["file"]
-            if not fpath.is_file():
-                continue
-            devices.append({
-                "hostname": d.get("hostname", fpath.stem),
-                "function": d.get("function", "unknown"),
-                "platform": manifest.get("vendor", "junos").lower(),
-                "config_text": fpath.read_text(encoding="utf-8", errors="replace"),
-            })
+        # Shared loader keeps per-device platform intact — the old inline loop
+        # stamped every device with the manifest-level vendor string, which is
+        # wrong on mixed-vendor sites (e.g. "multi (Nokia SRL + Arista cEOS…)").
+        devices, _manifest = _load_site_devices(safe)
+        if devices is None:
+            return jsonify({"error": f"site bundle not found: {safe}"}), 404
         if not devices:
             return jsonify({"error": "no device configs found in bundle"}), 404
 
@@ -851,10 +880,12 @@ def create_app() -> Flask:
         return jsonify({"ok": removed})
 
     @app.route("/api/sources/<source_id>/test", methods=["POST"])
+    @require_api_token
     def api_sources_test(source_id: str):
         return jsonify(source_manager.healthcheck(source_id))
 
     @app.route("/api/sources/<source_id>/fetch", methods=["POST"])
+    @require_api_token
     def api_sources_fetch(source_id: str):
         """Pull a batch of events from a registered source. Body:
         {since_seconds, limit, host_filter}."""

--- a/src/ai_log_analyzer/web/static/app.js
+++ b/src/ai_log_analyzer/web/static/app.js
@@ -785,8 +785,9 @@ function render(r) {
         const hostLabel = t.host_count > 3
           ? `${t.host_count}: ${t.hosts.slice(0, 3).join(", ")}…`
           : t.hosts.join(", ");
+        const flags = (t.severity_hint !== "info" ? "⚠" : "") + (t.is_new ? " 🆕" : "");
         const tr = el("tr", { className: t.severity_hint !== "info" ? "sev-row-medium" : "" },
-          el("td", { text: t.severity_hint !== "info" ? "⚠" : "" }),
+          el("td", { text: flags.trim() }),
           el("td", {}, el("span", { className: "row-msg", text: t.template })),
           el("td", { text: String(t.count) }),
           el("td", { text: hostLabel }),

--- a/src/ai_log_analyzer/web/static/app.js
+++ b/src/ai_log_analyzer/web/static/app.js
@@ -770,6 +770,34 @@ function render(r) {
     aTbody.appendChild(tr);
   });
 
+  // Unknown patterns (mined templates of lines no KB rule matched)
+  const up = r.unknown_patterns || {};
+  const upTemplates = up.top_templates || [];
+  const upPanel = $("unknown-panel");
+  if (upPanel) {
+    if (upTemplates.length) {
+      upPanel.style.display = "block";
+      $("unknown-count").textContent =
+        `(${up.template_count} templates · ${up.total_unclassified} lines)`;
+      const uTbody = $("unknown-table").querySelector("tbody");
+      clear(uTbody);
+      upTemplates.forEach((t) => {
+        const hostLabel = t.host_count > 3
+          ? `${t.host_count}: ${t.hosts.slice(0, 3).join(", ")}…`
+          : t.hosts.join(", ");
+        const tr = el("tr", { className: t.severity_hint !== "info" ? "sev-row-medium" : "" },
+          el("td", { text: t.severity_hint !== "info" ? "⚠" : "" }),
+          el("td", {}, el("span", { className: "row-msg", text: t.template })),
+          el("td", { text: String(t.count) }),
+          el("td", { text: hostLabel }),
+        );
+        uTbody.appendChild(tr);
+      });
+    } else {
+      upPanel.style.display = "none";
+    }
+  }
+
   // Events
   $("events-panel").style.display = "block";
   const totalEvents = (r.classified_events || []).length;

--- a/src/ai_log_analyzer/web/static/index.html
+++ b/src/ai_log_analyzer/web/static/index.html
@@ -1439,7 +1439,7 @@
 
     <div class="panel" id="unknown-panel" style="display:none;">
       <h2>🔭 Unknown Patterns <span class="h2-count" id="unknown-count"></span></h2>
-      <p class="row-msg" style="margin:0 0 8px;">Message shapes no knowledge-base rule matched, mined into templates (variables masked as &lt;ip&gt;/&lt;n&gt;/&lt;if&gt;). A brand-new error shape often precedes an outage — review the ⚠ rows first.</p>
+      <p class="row-msg" style="margin:0 0 8px;">Message shapes no knowledge-base rule matched, mined into templates (variables masked as &lt;ip&gt;/&lt;n&gt;/&lt;if&gt;). A brand-new error shape often precedes an outage — review ⚠ rows first. 🆕 marks shapes never seen in any prior run (set <code>AI_LOG_ANALYZER_TEMPLATE_STORE</code> to enable).</p>
       <table id="unknown-table">
         <thead>
           <tr><th></th><th>Template</th><th>Count</th><th>Hosts</th></tr>

--- a/src/ai_log_analyzer/web/static/index.html
+++ b/src/ai_log_analyzer/web/static/index.html
@@ -231,6 +231,7 @@
   #health-panel          { contain-intrinsic-size: 0 320px; }
   #summary-panel         { contain-intrinsic-size: 0 260px; }
   #actions-panel         { contain-intrinsic-size: 0 380px; }
+  #unknown-panel         { contain-intrinsic-size: 0 300px; }
   #events-panel          { contain-intrinsic-size: 0 540px; }
   #optimize-panel        { contain-intrinsic-size: 0 800px; }
   #site-panel            { contain-intrinsic-size: 0 720px; }
@@ -1431,6 +1432,17 @@
       <table id="actions-table">
         <thead>
           <tr><th>Severity</th><th>Description</th><th>Count</th><th>Devices</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <div class="panel" id="unknown-panel" style="display:none;">
+      <h2>🔭 Unknown Patterns <span class="h2-count" id="unknown-count"></span></h2>
+      <p class="row-msg" style="margin:0 0 8px;">Message shapes no knowledge-base rule matched, mined into templates (variables masked as &lt;ip&gt;/&lt;n&gt;/&lt;if&gt;). A brand-new error shape often precedes an outage — review the ⚠ rows first.</p>
+      <table id="unknown-table">
+        <thead>
+          <tr><th></th><th>Template</th><th>Count</th><th>Hosts</th></tr>
         </thead>
         <tbody></tbody>
       </table>

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -1,0 +1,119 @@
+"""Tests for user-defined classification rules (classifier custom rules + API)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai_log_analyzer import classifier
+from ai_log_analyzer.classifier import LogEvent, classify_events
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_custom_rules():
+    """Isolate each test from module-global custom-rule state."""
+    saved = list(classifier._CUSTOM_RULES)
+    classifier._CUSTOM_RULES.clear()
+    yield
+    classifier._CUSTOM_RULES[:] = saved
+
+
+def _event(message: str, appname: str = "app") -> LogEvent:
+    return LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
+                    appname=appname, severity_raw="info", message=message)
+
+
+def test_add_custom_rule_and_classify():
+    added, errors = classifier.add_custom_rules([{
+        "pattern": r"widget.*meltdown",
+        "severity": "critical",
+        "category": "custom",
+        "description": "Widget meltdown detected",
+    }])
+    assert added == 1 and not errors
+    events, sev, _cat = classify_events([_event("widget core meltdown imminent")])
+    assert events[0].severity == "critical"
+    assert events[0].description == "Widget meltdown detected"
+    assert sev["critical"] == 1
+
+
+def test_custom_rule_overrides_builtin():
+    # Built-in KB says "bgp peer down" is high/routing; operator overrides.
+    classifier.add_custom_rules([{
+        "pattern": r"bgp.*down",
+        "severity": "low",
+        "category": "known-noise",
+        "description": "Lab BGP flap — ignore",
+    }])
+    events, _, _ = classify_events([_event("bgp peer 10.0.0.1 down")])
+    assert events[0].severity == "low"
+    assert events[0].category == "known-noise"
+
+
+def test_invalid_rules_are_skipped_with_errors():
+    added, errors = classifier.add_custom_rules([
+        {"pattern": "(unclosed", "severity": "high"},
+        {"pattern": "ok", "severity": "not-a-severity"},
+        "not-a-dict",
+        {"pattern": "fine", "severity": "medium"},
+    ])
+    assert added == 1
+    assert len(errors) == 3
+
+
+def test_load_custom_rules_file(tmp_path):
+    rules_file = tmp_path / "rules.json"
+    rules_file.write_text(json.dumps([
+        {"pattern": "gizmo.*offline", "severity": "high",
+         "category": "gizmo", "description": "Gizmo went offline"},
+    ]))
+    added, errors = classifier.load_custom_rules_file(str(rules_file))
+    assert added == 1 and not errors
+    events, _, _ = classify_events([_event("gizmo controller offline")])
+    assert events[0].category == "gizmo"
+
+
+def test_load_custom_rules_file_missing():
+    added, errors = classifier.load_custom_rules_file("/nonexistent/rules.json")
+    assert added == 0 and errors
+
+
+# ── API endpoints ────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def client():
+    from ai_log_analyzer.web.app import create_app
+    app = create_app()
+    app.testing = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_api_rules_get(client):
+    resp = client.get("/api/rules")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["builtin_count"] > 50
+    assert body["custom"] == []
+
+
+def test_api_rules_post_and_list(client):
+    resp = client.post("/api/rules", json={"rules": [
+        {"pattern": "foo.*bar", "severity": "medium",
+         "category": "custom", "description": "foo-bar"},
+    ]})
+    assert resp.status_code == 200
+    assert resp.get_json()["added"] == 1
+    listed = client.get("/api/rules").get_json()
+    assert any(r["description"] == "foo-bar" for r in listed["custom"])
+
+
+def test_api_rules_post_rejects_bad_body(client):
+    assert client.post("/api/rules", json={}).status_code == 400
+    assert client.post("/api/rules", json={"rules": []}).status_code == 400
+    resp = client.post("/api/rules", json={"rules": [{"pattern": "(", "severity": "high"}]})
+    assert resp.status_code == 400
+    assert resp.get_json()["added"] == 0

--- a/tests/test_llm_sanitize_gate.py
+++ b/tests/test_llm_sanitize_gate.py
@@ -1,0 +1,58 @@
+"""Regression: raw log samples must pass the sanitize gate before any LLM call.
+
+The config paths (optimize_config / analyze_site / copilot) always sanitized;
+the *log* path (deep_analyze sample_messages) did not — contradicting the
+project's core "sanitize-before-LLM" guarantee.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ai_log_analyzer import analyzer, llm
+
+
+pytestmark = pytest.mark.unit
+
+SECRET_LINE = "login attempt snmp-server community SuperSecret123 ro rejected"
+
+
+def test_deep_analyze_sanitizes_sample_messages(monkeypatch):
+    captured: dict = {}
+
+    def fake_query(system_prompt, user_prompt, max_tokens=0, **kwargs):
+        captured["prompt"] = user_prompt
+        return None  # fall back to KB — we only care what went out
+
+    monkeypatch.setattr(llm, "query", fake_query)
+    analyzer.deep_analyze(
+        category="security",
+        description="Authentication failure",
+        devices=["r1"],
+        count=3,
+        sample_messages=[SECRET_LINE],
+        skip_llm=False,
+    )
+    assert "prompt" in captured, "LLM path was not exercised"
+    assert "SuperSecret123" not in captured["prompt"]
+    assert "<REDACTED>" in captured["prompt"]
+
+
+def test_deep_analyze_sanitizes_description(monkeypatch):
+    captured: dict = {}
+
+    def fake_query(system_prompt, user_prompt, max_tokens=0, **kwargs):
+        captured["prompt"] = user_prompt
+        return None
+
+    monkeypatch.setattr(llm, "query", fake_query)
+    # Severity-promoted events with no KB match carry a raw message snippet
+    # as their description.
+    analyzer.deep_analyze(
+        category="other",
+        description=SECRET_LINE,
+        devices=["r1"],
+        count=1,
+        sample_messages=[],
+        skip_llm=False,
+    )
+    assert "SuperSecret123" not in captured["prompt"]

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -98,7 +98,8 @@ def test_to_dict_shape():
     assert d["total_unclassified"] == 1
     assert d["template_count"] == 1
     t = d["top_templates"][0]
-    assert set(t) == {"template", "count", "hosts", "host_count", "sample", "severity_hint"}
+    assert set(t) == {"template", "count", "hosts", "host_count", "sample",
+                      "severity_hint", "is_new"}
     assert t["hosts"] == ["r1"]
 
 
@@ -119,6 +120,64 @@ def test_analyze_surfaces_unknown_patterns():
     assert up["total_unclassified"] == 20
     assert up["template_count"] == 1
     assert "<n>" in up["top_templates"][0]["template"]
+
+
+def test_template_store_flags_new_templates_across_runs(tmp_path):
+    from ai_log_analyzer.patterns import TemplateStore
+
+    store_path = tmp_path / "templates.json"
+
+    # Run 1: everything is new.
+    m1 = TemplateMiner()
+    m1.add("thermal envelope exceeded on chip 3")
+    store = TemplateStore(store_path)
+    assert store.mark_and_update(m1) == 1
+    assert m1.top(1)[0].is_new is True
+    store.save()
+
+    # Run 2: same shape → known; a different shape → new.
+    m2 = TemplateMiner()
+    m2.add("thermal envelope exceeded on chip 7")   # same masked template
+    m2.add("gravity plating desynchronized")        # brand new
+    store2 = TemplateStore(store_path)
+    assert store2.mark_and_update(m2) == 1
+    by_template = {c.template: c for c in m2.top(10)}
+    assert by_template["thermal envelope exceeded on chip <n>"].is_new is False
+    assert by_template["gravity plating desynchronized"].is_new is True
+
+
+def test_template_store_bounded_and_corrupt_file_tolerated(tmp_path):
+    from ai_log_analyzer.patterns import TemplateStore
+
+    corrupt = tmp_path / "bad.json"
+    corrupt.write_text("{not json")
+    store = TemplateStore(corrupt)          # must not raise
+    assert len(store) == 0
+
+    small = TemplateStore(tmp_path / "small.json", max_entries=3)
+    m = TemplateMiner()
+    for i in range(6):
+        m.add(f"unique{i} standalone shape number{i} alpha")
+    small.mark_and_update(m)
+    assert len(small) <= 3
+
+
+def test_apply_template_store_via_env(tmp_path, monkeypatch):
+    from ai_log_analyzer.analyzer import analyze
+    from ai_log_analyzer.classifier import LogEvent
+
+    store_path = tmp_path / "store.json"
+    monkeypatch.setenv("AI_LOG_ANALYZER_TEMPLATE_STORE", str(store_path))
+
+    events = [LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
+                       appname="zapd", severity_raw="info",
+                       message="ionizer array recalibrated spontaneously")]
+    r1 = analyze(iter(events), use_llm=False)
+    assert r1.unknown_patterns["new_template_count"] == 1
+    assert store_path.is_file()
+
+    r2 = analyze(iter(events), use_llm=False)
+    assert r2.unknown_patterns["new_template_count"] == 0
 
 
 def test_analyze_kb_matched_events_not_mined():

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,134 @@
+"""Tests for the unknown-pattern template miner (patterns.py)."""
+from __future__ import annotations
+
+import pytest
+
+from ai_log_analyzer.patterns import TemplateMiner, mask_message
+
+
+pytestmark = pytest.mark.unit
+
+
+# ── masking ──────────────────────────────────────────────────────────────────
+
+def test_mask_ipv4_and_numbers():
+    assert mask_message("peer 10.0.0.1 reset after 42 tries") == "peer <ip> reset after <n> tries"
+
+
+def test_mask_ip_with_port_and_prefix():
+    assert mask_message("connect 192.168.1.1:179 failed") == "connect <ip> failed"
+    assert mask_message("route 10.20.0.0/16 withdrawn") == "route <ip> withdrawn"
+
+
+def test_mask_mac_and_hex():
+    assert mask_message("mac aa:bb:cc:dd:ee:ff moved") == "mac <mac> moved"
+    assert mask_message("addr 0xdeadbeef fault") == "addr <hex> fault"
+
+
+def test_mask_interfaces():
+    assert mask_message("ge-0/0/1 flapped") == "<if> flapped"
+    assert mask_message("Ethernet49/1 errdisabled") == "<if> errdisabled"
+
+
+def test_mask_preserves_words():
+    assert mask_message("kernel module loaded") == "kernel module loaded"
+
+
+# ── clustering ───────────────────────────────────────────────────────────────
+
+def test_same_shape_clusters_together():
+    m = TemplateMiner()
+    for i in range(50):
+        m.add(f"session {i} torn down for peer 10.0.0.{i % 9}", hostname=f"h{i % 3}")
+    assert m.cluster_count == 1
+    top = m.top(1)[0]
+    assert top.count == 50
+    assert top.template == "session <n> torn down for peer <ip>"
+    assert len(top.hosts) == 3
+
+
+def test_different_shapes_stay_separate():
+    m = TemplateMiner()
+    m.add("power rail B undervoltage detected")
+    m.add("optical transceiver removed from slot 3")
+    assert m.cluster_count == 2
+
+
+def test_similar_shapes_merge_with_wildcard():
+    m = TemplateMiner(sim_threshold=0.55)
+    m.add("service restart requested by operator alice")
+    m.add("service restart requested by operator bob")
+    assert m.cluster_count == 1
+    assert m.top(1)[0].template == "service restart requested by operator <*>"
+
+
+def test_errorish_hint_promoted():
+    m = TemplateMiner()
+    m.add("cache rebuild failed on shard 4")
+    m.add("heartbeat received from controller")
+    by_template = {c.template: c for c in m.top(10)}
+    assert by_template["cache rebuild failed on shard <n>"].severity_hint == "warning"
+    assert by_template["heartbeat received from controller"].severity_hint == "info"
+
+
+def test_top_ranks_errorish_first():
+    m = TemplateMiner()
+    for _ in range(100):
+        m.add("routine heartbeat tick")
+    m.add("disk write failure on volume 2")
+    top = m.top(2)
+    assert "failure" in top[0].template  # errorish beats higher-volume benign
+
+
+def test_lru_eviction_bounds_memory():
+    m = TemplateMiner(max_clusters=10)
+    for i in range(50):
+        m.add(f"unique{i} shape{i} alpha beta gamma delta")
+    assert m.cluster_count <= 10
+    # groups index must not leak evicted ids
+    live = set(m._clusters)
+    for ids in m._groups.values():
+        assert set(ids) <= live
+
+
+def test_to_dict_shape():
+    m = TemplateMiner()
+    m.add("widget 7 exploded", hostname="r1")
+    d = m.to_dict()
+    assert d["total_unclassified"] == 1
+    assert d["template_count"] == 1
+    t = d["top_templates"][0]
+    assert set(t) == {"template", "count", "hosts", "host_count", "sample", "severity_hint"}
+    assert t["hosts"] == ["r1"]
+
+
+# ── analyzer integration ─────────────────────────────────────────────────────
+
+def test_analyze_surfaces_unknown_patterns():
+    from ai_log_analyzer.analyzer import analyze
+    from ai_log_analyzer.classifier import LogEvent
+
+    events = [
+        LogEvent(timestamp=f"2026-01-01T00:00:{i:02d}", hostname="r1",
+                 appname="fooagent", severity_raw="info",
+                 message=f"quantum flux capacitor recalibrated {i} times")
+        for i in range(20)
+    ]
+    result = analyze(iter(events), use_llm=False)
+    up = result.to_dict()["unknown_patterns"]
+    assert up["total_unclassified"] == 20
+    assert up["template_count"] == 1
+    assert "<n>" in up["top_templates"][0]["template"]
+
+
+def test_analyze_kb_matched_events_not_mined():
+    from ai_log_analyzer.analyzer import analyze
+    from ai_log_analyzer.classifier import LogEvent
+
+    events = [
+        LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
+                 appname="rpd", severity_raw="err",
+                 message="bgp peer 10.0.0.1 down hold timer expired"),
+    ]
+    result = analyze(iter(events), use_llm=False)
+    assert result.unknown_patterns["total_unclassified"] == 0

--- a/tests/test_reports_runbook_topology.py
+++ b/tests/test_reports_runbook_topology.py
@@ -1,0 +1,209 @@
+"""Coverage for modules phases 0-12 left untested: reports.py, runbook.py,
+topology.py, and their web routes (/api/report, /api/runbook, /api/topology,
+plus the 400-paths of /api/diff and /api/copilot).
+"""
+from __future__ import annotations
+
+import pytest
+
+from ai_log_analyzer import reports, runbook
+from ai_log_analyzer import topology as topo_mod
+
+
+pytestmark = pytest.mark.unit
+
+
+SITE_RESULT = {
+    "site_id": "LAB-X",
+    "site_summary": "Two HA firewalls drifted.",
+    "site_score": 72,
+    "llm_powered": True,
+    "topology": {
+        "devices_seen": ["fw-01", "fw-02"],
+        "roles": {"firewall": ["fw-01", "fw-02"]},
+        "isp_uplinks": ["fw-01: isp_a"],
+    },
+    "cross_device_findings": [{
+        "severity": "high",
+        "category": "ha_drift",
+        "title": "BFD enabled on fw-01 but not fw-02",
+        "affected_devices": ["fw-01", "fw-02"],
+        "evidence": "fw-01: set protocols bgp bfd",
+        "rationale": "Asymmetric failover detection.",
+        "fix_per_device": {"fw-02": ["set protocols bgp group isp bfd-liveness-detection minimum-interval 300"]},
+        "verify_cli": ["show bfd session"],
+    }],
+    "monitoring_gaps": ["Alert when BFD session count drops"],
+}
+
+OPTIMIZE_RESULT = {
+    "hostname": "rt-01",
+    "platform": "junos",
+    "score": 80,
+    "summary": "Mostly sane.",
+    "llm_powered": False,
+    "findings": [{
+        "severity": "medium",
+        "category": "monitoring",
+        "title": "No SNMPv3",
+        "evidence": "snmp { community public; }",
+        "rationale": "Cleartext SNMP.",
+        "patch": ["set snmp v3 usm local-engine user monitor"],
+    }],
+}
+
+
+# ── reports.py ───────────────────────────────────────────────────────────────
+
+def test_markdown_site_report_carries_findings_and_fixes():
+    md = reports.to_markdown_site(SITE_RESULT)
+    assert "# Site Analysis: LAB-X" in md
+    assert "[HIGH] BFD enabled on fw-01 but not fw-02" in md
+    assert "set protocols bgp group isp bfd-liveness-detection" in md
+    assert "Monitoring Gaps (1)" in md
+
+
+def test_markdown_optimize_report():
+    md = reports.to_markdown_optimize(OPTIMIZE_RESULT)
+    assert "rt-01" in md
+    assert "[MEDIUM] No SNMPv3" in md
+    assert "set snmp v3" in md
+
+
+def test_csv_findings_handles_both_result_shapes():
+    site_csv = reports.to_csv_findings(SITE_RESULT)
+    assert "severity,category,title,affected,evidence,rationale" in site_csv
+    assert "fw-01, fw-02" in site_csv
+    dev_csv = reports.to_csv_findings(OPTIMIZE_RESULT)
+    assert "No SNMPv3" in dev_csv
+    assert "rt-01" in dev_csv
+
+
+def test_html_site_report_is_standalone_html():
+    html = reports.to_html_site(SITE_RESULT, mermaid_diagram="graph TD; a-->b")
+    assert "<html" in html.lower()
+    assert "BFD enabled on fw-01" in html
+    assert "graph TD" in html
+
+
+# ── runbook.py ───────────────────────────────────────────────────────────────
+
+def test_ansible_playbook_per_platform_module():
+    f = SITE_RESULT["cross_device_findings"][0]
+    junos = runbook.to_ansible_playbook(f, ["fw-02"], platform_hint="junos")
+    assert "junipernetworks.junos.junos_config" in junos
+    assert "bfd-liveness-detection" in junos
+    eos = runbook.to_ansible_playbook(f, ["sw-01"], platform_hint="eos")
+    assert "arista.eos.eos_config" in eos
+    frr = runbook.to_ansible_playbook(f, ["r1"], platform_hint="frr")
+    assert "ansible.builtin.shell" in frr
+
+
+def test_netmiko_script_device_type_and_commands():
+    f = OPTIMIZE_RESULT["findings"][0]
+    py = runbook.to_netmiko_script(f, ["rt-01"], platform_hint="junos")
+    assert "juniper_junos" in py
+    assert "set snmp v3" in py
+    assert "PASSWORD = os.environ.get" in py  # never hardcoded
+
+
+def test_extract_cmds_dedups_across_shapes():
+    finding = {
+        "patch": ["cmd a", "cmd b"],
+        "fix_per_device": {"h1": ["cmd a"]},
+        "deep_analysis": {"phases": [{"actions": [
+            {"cli": {"junos": "cmd c"}},
+            {"cli": {"any": "cmd b"}},
+        ]}]},
+    }
+    cmds = runbook._extract_cmds(finding, "junos")
+    assert cmds == ["cmd a", "cmd b", "cmd c"]
+
+
+# ── topology.py (against a bundled site) ─────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def lab_alpha_topo():
+    from ai_log_analyzer.web.app import _load_site_devices
+    devices, manifest = _load_site_devices("lab-alpha")
+    assert devices, "bundled lab-alpha site must be present"
+    topo = topo_mod.build_topology("LAB-ALPHA", devices)
+    if manifest:
+        topo_mod.apply_manifest_metadata(topo, manifest)
+    return topo
+
+
+def test_build_topology_finds_nodes_and_edges(lab_alpha_topo):
+    d = lab_alpha_topo.to_dict()
+    assert len(d["nodes"]) == 5
+    assert d["edges"], "edge inference should find at least one link"
+    hostnames = {n["id"] for n in d["nodes"]}
+    assert any("fw-" in h for h in hostnames)
+
+
+def test_topology_export_formats(lab_alpha_topo):
+    mermaid = topo_mod.to_mermaid(lab_alpha_topo)
+    assert "graph TD" in mermaid
+    assert "alpha_fw_01a" in mermaid
+    dot = topo_mod.to_graphviz(lab_alpha_topo)
+    assert "graph" in dot.split("\n", 1)[0]
+
+
+def test_overlay_findings_marks_affected_nodes(lab_alpha_topo):
+    d0 = lab_alpha_topo.to_dict()
+    target = d0["nodes"][0]["id"]
+    topo_mod.overlay_findings(lab_alpha_topo, [
+        {"severity": "critical", "affected_devices": [target]},
+    ])
+    node = next(n for n in lab_alpha_topo.to_dict()["nodes"] if n["id"] == target)
+    assert node.get("finding_severity") == "critical"
+
+
+# ── web routes ───────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def client():
+    from ai_log_analyzer.web.app import create_app
+    app = create_app()
+    app.testing = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_api_topology_json_mermaid_dot(client):
+    r = client.get("/api/topology/lab-alpha")
+    assert r.status_code == 200
+    assert len(r.get_json()["nodes"]) == 5
+    r = client.get("/api/topology/lab-alpha?format=mermaid")
+    assert r.status_code == 200 and b"graph" in r.data
+    r = client.get("/api/topology/lab-alpha?format=dot")
+    assert r.status_code == 200
+    assert client.get("/api/topology/no-such-site").status_code == 404
+    assert client.get("/api/topology/bad.id").status_code == 400
+
+
+def test_api_runbook_formats(client):
+    body = {"finding": OPTIMIZE_RESULT["findings"][0],
+            "hostnames": ["rt-01"], "platform": "junos"}
+    r = client.post("/api/runbook", json={**body, "format": "ansible"})
+    assert r.status_code == 200 and b"junos_config" in r.data
+    r = client.post("/api/runbook", json={**body, "format": "python"})
+    assert r.status_code == 200 and b"ConnectHandler" in r.data
+    assert client.post("/api/runbook", json={**body, "format": "bogus"}).status_code == 400
+    assert client.post("/api/runbook", json={"format": "ansible"}).status_code == 400
+
+
+def test_api_report_md_and_csv(client):
+    r = client.post("/api/report/lab-alpha",
+                    json={"format": "md", "analysis_result": SITE_RESULT})
+    assert r.status_code == 200 and b"Site Analysis" in r.data
+    r = client.post("/api/report/lab-alpha",
+                    json={"format": "csv", "analysis_result": OPTIMIZE_RESULT})
+    assert r.status_code == 200 and b"No SNMPv3" in r.data
+    assert client.post("/api/report/lab-alpha", json={"format": "md"}).status_code == 400
+
+
+def test_api_diff_and_copilot_validation(client):
+    assert client.post("/api/diff", json={"before": "x"}).status_code == 400
+    assert client.post("/api/copilot", json={}).status_code == 400
+    assert client.post("/api/copilot", json={"question": "hi"}).status_code == 400

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -335,6 +335,11 @@ def test_syslog_udp_listener_receives_messages():
         assert "ospf" in joined
         # Hostname should be parsed out from the RFC3164 frame
         assert any(e.hostname == "fra4-fw-01" for e in events)
+        # fetch() must be idempotent like every other connector — a second
+        # call (e.g. correlate → triage on the same source) sees the same
+        # events instead of an emptied buffer.
+        events_again = list(src.fetch(since_seconds=60, limit=100))
+        assert len(events_again) == len(events)
     finally:
         src.close()
 

--- a/tests/test_streaming_analyze.py
+++ b/tests/test_streaming_analyze.py
@@ -76,11 +76,14 @@ def test_aggregate_stream_is_bounded():
                 message=f"job {i} completed",
             )
 
-    top, sev, cat, groups, by_host = _aggregate_stream(iter_classify(synth(20_000)), top_k=300)
+    top, sev, cat, groups, by_host, miner = _aggregate_stream(iter_classify(synth(20_000)), top_k=300)
     assert sev["info"] == 20_000
     assert len(top) <= 300
     assert len(by_host) == 7
     assert not groups  # info events never become action items
+    # 20k unmatched lines share one shape once numbers are masked → 1 template
+    assert miner.cluster_count <= 2
+    assert miner.to_dict()["total_unclassified"] == 20_000
 
 
 # ── web size guard + generator path ─────────────────────────────────────────

--- a/tests/test_tfsm_auto.py
+++ b/tests/test_tfsm_auto.py
@@ -22,6 +22,16 @@ if not tfsm_auto.is_available():
     pytest.skip("tfsm-fire not installed (install with: pip install netlog-ai[parse])",
                 allow_module_level=True)
 
+# The template DB is a third-party download (upstream GitHub raw file). When
+# upstream is unreachable or has restructured (404), the adapter degrades to
+# no-match by design — skip the end-to-end tests rather than fail CI on an
+# external outage. Point TFSM_DB_URL at a mirror or TFSM_DB_PATH at a local
+# copy to re-enable them.
+if tfsm_auto._get_engine() is None:
+    pytest.skip("tfsm_fire template DB unavailable (upstream download failed — "
+                "set TFSM_DB_URL/TFSM_DB_PATH to a mirror or local copy)",
+                allow_module_level=True)
+
 
 # ---------------------------------------------------------------------------
 # Canned device output fixtures. These are intentionally short and well-formed

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -44,6 +44,27 @@ def test_token_set_accepts_correct_token(client, monkeypatch):
     assert r.status_code != 401  # passes the gate; body validation may 400
 
 
+@pytest.mark.unit
+def test_token_accepts_authorization_bearer(client, monkeypatch):
+    monkeypatch.setattr(web_app, "API_TOKEN", "sekrit")
+    r = client.post("/api/llm/provider", json={},
+                    headers={"Authorization": "Bearer sekrit"})
+    assert r.status_code != 401
+    r = client.post("/api/llm/provider", json={},
+                    headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_sources_test_and_fetch_require_token(client, monkeypatch):
+    """/api/sources/<id>/test and /fetch were the only POST data routes
+    missing the auth gate — regression check that they now enforce it."""
+    monkeypatch.setattr(web_app, "API_TOKEN", "sekrit")
+    assert client.post("/api/sources/x/test").status_code == 401
+    assert client.post("/api/sources/x/fetch", json={}).status_code == 401
+    assert client.post("/api/rules", json={}).status_code == 401
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # /api/analyze {source:"file"} path confinement
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

A deep product-analysis pass: market research on how production AIOps pipelines handle network syslog (Drain3 / IBM DeCorus / IncidentFox-class tools), plus a full audit of the repo's development history (PRs #1–#11). The single biggest analytical gap: **any log line the 55-pattern regex KB can't match silently becomes `info`/`other` and disappears** — while the strongest early-warning signal in the field is precisely "a message shape never seen before just appeared."

## Added

- **🔭 Unknown-pattern template mining** (`patterns.py`, zero dependencies) — every unmatched line is masked (`<ip>/<mac>/<hex>/<if>/<n>/<ts>`) and clustered with a Drain-style fixed-depth miner (similar shapes merge into `<*>` wildcards, LRU-bounded memory so the streaming pipeline stays flat at any input size). Results surface as `unknown_patterns` in `/api/analyze`, the MCP `analyze_logs` tool, and a new **Unknown Patterns** UI panel — error-smelling templates ranked first.
- **🆕 Cross-run template persistence** — set `AI_LOG_ANALYZER_TEMPLATE_STORE` and the miner remembers every shape across runs (FIFO-bounded JSON store, atomic writes, corrupt-file tolerant). Shapes never seen in *any* prior run are flagged `is_new` / `new_template_count` / 🆕 in the UI — the classic AIOps early-warning.
- **Custom classification rules** (roadmap item) — a JSON rules file loaded at startup (`AI_LOG_ANALYZER_CUSTOM_RULES`) plus a runtime API (`GET/POST /api/rules`). Custom rules run *before* the built-in KB, so operators can demote known noise or promote site-specific failures.

## Security (audit findings)

- **Log→LLM path now passes the sanitize gate.** `deep_analyze()` sent raw sample log lines (and severity-promoted raw descriptions) to the LLM unsanitized; config paths were always scrubbed but logs were not — contradicting the project's core sanitize-before-LLM guarantee.
- **`/api/sources/<id>/test` and `/fetch` now require the API token** — the only POST data routes missing the gate (data egress + probe surface).
- **`Authorization: Bearer` accepted** alongside `X-API-Token` — the README documented Bearer while the code only accepted the custom header, locking out users who followed the docs.

## Fixed

- MCP server resolves packaged `data/sites` — `list_sites`/`analyze_site` returned empty on any `pip install netlog-ai[mcp]` wheel (repo-root-only lookup).
- `/api/optimize/site` now uses the shared site loader — per-device `platform` preserved on mixed-vendor sites (was stamping every device with e.g. `multi (Nokia SRL + Arista cEOS + FRR)`).
- Syslog connector `fetch()` is idempotent — it drained the ring buffer, so correlate → triage on the same source saw zero events on the second call.
- Default Ollama model `gemma4:latest` → `qwen2.5-coder:latest` (gemma4 doesn't exist and ollama is the default provider — out-of-box LLM calls failed silently).
- tfsm_fire end-to-end tests skip gracefully when the upstream template-DB download 404s (upstream restructured); `TFSM_DB_URL` override added for mirrors.
- Env source loader no longer leaks `verify_tls`/`timeout_seconds` into `extra`.
- `.env.example`/README now document the real security env vars (`AI_LOG_ANALYZER_API_TOKEN`, `AI_LOG_ANALYZER_CORS_ORIGINS`, `ANALYZER_HOST`, `AI_LOG_ANALYZER_FILE_ROOTS`), the `ollama` provider, and correct defaults (`LLM_TIMEOUT=120`).

## Tests

294 → **325 passed** (2 skipped), ruff clean. New coverage: miner masking/clustering/eviction/integration, template-store persistence, custom rules (engine + API + precedence), sanitize-gate regressions, auth regressions, syslog idempotency, plus a coverage wave for the modules earlier phases left untested — `reports.py`, `runbook.py`, `topology.py`, and web routes `/api/report`, `/api/runbook`, `/api/topology`, `/api/diff`, `/api/copilot`.

## Suggested next features (researched, not in this PR)

1. **Per-template volume anomaly detection** — count templates per device per time window; sudden rate spikes/drops flag outages before severity rules do.
2. **Incident timeline reconstruction** — burst-window grouping across devices to identify the first trigger event in a cascade.
3. **Real-time tail mode** (existing roadmap) — the syslog connector + miner are now both streaming-safe, making a websocket live view straightforward.
4. **Vendor the tfsm template DB or pin a mirror** — upstream is gone, so `netlog-ai[parse]` has no DB source for fresh installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XM7j9iDXYwSvjnxZYjzaq