### PR TITLE
feat: fabric stability engine + LLM-as-Judge playbook scoring (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,28 @@ All notable changes to **netlog-ai** are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses
 loose semantic versioning.
 
-## [Unreleased]
+## [0.4.0] - 2026-07-13
 
 ### Added
+
+- **Fabric stability engine** (`stability.py`) — per-device flap detection
+  (down↔up oscillation of interfaces / BGP peers / OSPF neighbors / LAG
+  members / VPN tunnels), event-rate burst detection against each device's
+  own baseline, rising/stable/falling trend, and a deterministic 24h risk
+  band. Surfaces as `stability` in `/api/analyze` + MCP and a **📶 Fabric
+  Stability** panel in the UI (worst devices first, actionable
+  recommendations). Streaming-safe: O(devices × entity classes) memory,
+  minute-prefix bucketing with arrival-order fallback so unreliable syslog
+  timestamps can't break it.
+- **LLM-as-Judge playbook scoring** (`judge.py` + `ai-log-analyzer eval`) —
+  scores generated playbooks 0–10 on actionability / safety / grounding /
+  completeness with a deterministic heuristic core (empty playbooks can't
+  ace safety "by absence"; disruptive commands without context are
+  penalized; R1/SW2-style placeholder names hurt grounding). Optional
+  `--use-llm` blends a real LLM judge via the configured provider, falling
+  back silently. `eval` self-tests every rule-based KB playbook by default,
+  scores a saved analyze result with `--file`, and `--min-score` makes it a
+  CI quality gate.
 
 - **Unknown-pattern template mining** (`patterns.py`) — every line the regex KB
   can't match is mined into templates with a dependency-free Drain-style

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > **Network logs in. Ranked actions out.** A local, dark-themed dashboard that classifies syslog events from any vendor (Junos, Arista EOS, FRR), builds a prioritized action list, and lets an LLM write the root-cause analysis with copy-pastable CLI fixes.
 
-[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-325%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
+[![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-338%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
 > 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
@@ -69,6 +69,8 @@ Tools exposed: `list_sources`, `add_source`, `fetch_logs`, `search_logs`,
 | 🔎 **Classify** | 50+ regex patterns across Junos, EOS, FRR, IOS, RFC-3164/5424 — plus your own rules via `AI_LOG_ANALYZER_CUSTOM_RULES` / `POST /api/rules` |
 | 🔭 **Unknown patterns** | Lines no rule matched are template-mined (Drain-style, zero deps): variables masked, shapes clustered, error-smelling templates ranked first — novel failure modes surface instead of vanishing as `info` noise. Set `AI_LOG_ANALYZER_TEMPLATE_STORE` for cross-run memory: shapes never seen in any prior run get flagged 🆕 |
 | 🧭 **Prioritize** | Deduped action items, ranked by severity × count, recovery events excluded |
+| 📶 **Fabric stability** | Per-device flap detection (interface/BGP/OSPF/LAG/VPN down↔up oscillation), event-rate bursts vs the device's own baseline, trend + heuristic 24h risk band — in `/api/analyze` and its own UI panel |
+| ⚖️ **LLM-as-Judge** | `ai-log-analyzer eval` scores playbooks 0–10 on actionability/safety/grounding/completeness — heuristic core, optional real LLM judge, `--min-score` CI gate |
 | 🧠 **Deep analyze** | Top-N items get an LLM-written root-cause + risk + remediation playbook |
 | 🛡️ **Sanitize-first** | Every config/log payload is scrubbed (`$6$`, `$9$`, SSH keys, SNMP, RADIUS, public IPs) before LLM call |
 | 📈 **Health score** | Weighted formula → 0–100 + A/B/C/D/F + sparkline trend |
@@ -105,6 +107,11 @@ ai-log-analyzer containers
 ai-log-analyzer analyze --frr r1 r2 --no-llm | jq .score
 ai-log-analyzer analyze --file /var/log/syslog
 docker logs my-router 2>&1 | ai-log-analyzer analyze --stdin
+
+# Score playbook quality (LLM-as-Judge; KB self-test by default)
+ai-log-analyzer eval                 # heuristic, offline
+ai-log-analyzer eval --use-llm       # blend a real LLM judge
+ai-log-analyzer eval --file result.json --min-score 7   # CI gate
 
 # Run the full test suite
 pytest --cov=src --cov-report=term-missing
@@ -319,6 +326,8 @@ flowchart TB
 src/ai_log_analyzer/
   classifier.py        50+ regex patterns + severity/category lookup + custom rules
   patterns.py          Drain-lite template miner for lines no rule matched
+  stability.py         Flap/burst/trend scoring + 24h risk per device
+  judge.py             LLM-as-Judge playbook quality scoring (eval CLI)
   kb.py                Rule-based deep-analysis KB (fallback when LLM is off)
   llm.py               Docker Model Runner (TCP + UDS) + Anthropic Claude
   analyzer.py          End-to-end pipeline: classify → actions → score → summary
@@ -398,7 +407,7 @@ src/ai_log_analyzer/
 
 ## Tested & accessible
 
-- **325 unit + integration tests** (pytest)
+- **338 unit + integration tests** (pytest)
 - Frontend audited across 8 review rounds:
   - WCAG-AA: `:focus-visible` rings, `aria-live` regions, `role=tablist/tab/tabpanel`, skip-to-main link, `prefers-reduced-motion` fallback
   - Responsive ≤ 1100px, PWA-ready (`theme-color`, `mobile-web-app-capable`, SVG favicon)
@@ -416,7 +425,8 @@ src/ai_log_analyzer/
 - [x] Custom classification rules — JSON file (`AI_LOG_ANALYZER_CUSTOM_RULES`) + runtime `POST /api/rules`; UI editor still open
 - [x] Unknown-pattern template mining — Drain-style clustering of unmatched lines, surfaced in UI/API/MCP
 - [x] Cross-run template persistence — `AI_LOG_ANALYZER_TEMPLATE_STORE` flags never-before-seen shapes (🆕)
-- [ ] Per-template volume anomaly detection (sudden rate spike/drop per device)
+- [x] Fabric stability scoring — flap/burst/trend detection + 24h risk band per device
+- [x] LLM-as-Judge playbook quality scoring (`ai-log-analyzer eval`, CI-gate ready)
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netlog-ai"
-version = "0.3.1"
+version = "0.4.0"
 description = "AI-powered network syslog analyzer with pluggable LLM providers (local Docker Model Runner / Anthropic Claude) and lab adapters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/ai_log_analyzer/analyzer.py
+++ b/src/ai_log_analyzer/analyzer.py
@@ -17,6 +17,7 @@ from ai_log_analyzer.classifier import (
 )
 from ai_log_analyzer.patterns import TemplateMiner, apply_template_store
 from ai_log_analyzer.sanitize import sanitize
+from ai_log_analyzer.stability import StabilityTracker
 
 
 # Recovery events are classified as medium because they're useful in the
@@ -91,6 +92,7 @@ class AnalysisResult:
     llm_powered: bool
     generated_at: str
     unknown_patterns: dict = field(default_factory=dict)
+    stability: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -106,6 +108,7 @@ class AnalysisResult:
             "llm_powered": self.llm_powered,
             "generated_at": self.generated_at,
             "unknown_patterns": self.unknown_patterns,
+            "stability": self.stability,
         }
 
 
@@ -515,7 +518,7 @@ def _executive_summary(
 
 def _aggregate_stream(
     classified: Iterable[ClassifiedEvent], top_k: int = 300,
-) -> tuple[list[ClassifiedEvent], dict[str, int], dict[str, int], dict, dict, TemplateMiner]:
+) -> tuple[list[ClassifiedEvent], dict[str, int], dict[str, int], dict, dict, TemplateMiner, StabilityTracker]:
     """Single bounded pass over a classified stream.
 
     Memory is O(top_k + KB rules + devices + template clusters) regardless of
@@ -532,12 +535,14 @@ def _aggregate_stream(
     groups: dict[tuple[str, str], dict] = {}
     by_host: dict[str, dict] = {}
     miner = TemplateMiner()
+    tracker = StabilityTracker()
 
     for seq, e in enumerate(classified):
         sev_counts[e.severity] = sev_counts.get(e.severity, 0) + 1
         cat_counts[e.category] = cat_counts.get(e.category, 0) + 1
         _group_actionable(e, groups, seq)
         _count_device(e, by_host)
+        tracker.add(e)
         if e.category == "other" and e.message:
             miner.add(e.message, e.hostname)
         heap = buckets.setdefault(e.severity, [])
@@ -554,7 +559,7 @@ def _aggregate_stream(
         )
         if len(top_events) >= top_k:
             break
-    return top_events[:top_k], sev_counts, cat_counts, groups, by_host, miner
+    return top_events[:top_k], sev_counts, cat_counts, groups, by_host, miner, tracker
 
 
 def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3) -> AnalysisResult:
@@ -565,7 +570,7 @@ def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3
     event list. Thread-safe: never mutates global llm state. `use_llm=False`
     is enforced by forcing `llm_top_n=0` and disabling the LLM exec summary.
     """
-    top_events, sev_counts, cat_counts, groups, by_host, miner = _aggregate_stream(
+    top_events, sev_counts, cat_counts, groups, by_host, miner, tracker = _aggregate_stream(
         iter_classify(events)
     )
     # Opt-in cross-run persistence: flags templates never seen in ANY prior
@@ -595,6 +600,7 @@ def analyze(events: Iterable[LogEvent], use_llm: bool = True, llm_top_n: int = 3
         llm_powered=any_llm,
         generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
         unknown_patterns=miner.to_dict(top_n=10),
+        stability=tracker.report(),
     )
 
 

--- a/src/ai_log_analyzer/cli.py
+++ b/src/ai_log_analyzer/cli.py
@@ -48,6 +48,48 @@ def cmd_containers(_args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_eval(args: argparse.Namespace) -> int:
+    """Score playbook quality with the LLM-as-Judge harness.
+
+    Default: self-test every rule-based KB playbook (the quality floor with
+    the LLM off). --file scores a saved /api/analyze JSON result instead.
+    --min-score turns the run into a CI gate (exit 1 below threshold).
+    """
+    from ai_log_analyzer import judge
+
+    if args.file:
+        try:
+            with open(args.file, encoding="utf-8") as fh:
+                result = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"error: cannot read {args.file}: {exc}", file=sys.stderr)
+            return 2
+        report = judge.judge_analysis_result(result, use_llm=args.use_llm)
+    else:
+        report = judge.judge_kb(use_llm=args.use_llm)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"Playbooks scored : {report['playbooks_scored']}")
+        print(f"Overall quality  : {report['overall']}/10")
+        print()
+        for v in report["verdicts"][: args.show]:
+            s = v["scores"]
+            label = v.get("description") or v.get("category", "")
+            print(f"  {s['overall']:>4}/10  [{v.get('judge')}] {label[:70]}")
+            print(f"          action={s['actionability']} safety={s['safety']} "
+                  f"grounding={s['grounding']} complete={s['completeness']}")
+            for note in v.get("notes", [])[:2]:
+                print(f"          ! {note}")
+
+    if args.min_score and report["overall"] < args.min_score:
+        print(f"\nFAIL: overall {report['overall']} < required {args.min_score}",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
 def cmd_mcp(args: argparse.Namespace) -> int:
     """Start the MCP server (stdio by default) so Claude Code / Cursor / Continue
     can call netlog-ai tools directly."""
@@ -82,6 +124,14 @@ def main() -> None:
 
     cp = sub.add_parser("containers", help="List running FRR lab containers")
     cp.set_defaults(func=cmd_containers)
+
+    ep = sub.add_parser("eval", help="Score playbook quality (LLM-as-Judge; KB self-test by default)")
+    ep.add_argument("--file", help="Saved /api/analyze JSON result to score (default: score the built-in KB)")
+    ep.add_argument("--use-llm", action="store_true", help="Blend in a real LLM judge (falls back to heuristic)")
+    ep.add_argument("--json", action="store_true", help="Machine-readable output")
+    ep.add_argument("--show", type=int, default=10, help="Verdicts to print, worst first (default 10)")
+    ep.add_argument("--min-score", type=float, default=0.0, help="Exit 1 if overall quality is below this (CI gate)")
+    ep.set_defaults(func=cmd_eval)
 
     mp = sub.add_parser("mcp", help="Run as an MCP server (for Claude Code / Cursor / Continue)")
     mp.add_argument("--transport", default="stdio", choices=["stdio", "streamable-http"],

--- a/src/ai_log_analyzer/judge.py
+++ b/src/ai_log_analyzer/judge.py
@@ -1,0 +1,239 @@
+"""LLM-as-Judge — score generated playbooks so quality regressions get caught.
+
+The product's core output is a remediation playbook (root cause, phased
+actions, CLI, monitoring). Nothing previously measured whether those
+playbooks are any good — an LLM regression or a KB edit could silently gut
+them. This module scores a playbook 0–10 on four dimensions:
+
+  * **actionability** — are there phases with real, copy-pasteable CLI,
+    expected outputs, preventive config?
+  * **safety** — do disruptive commands (reload / clear / shutdown) come with
+    context, and are secrets/placeholders handled properly?
+  * **grounding** — does it reference the real devices it was asked about,
+    not invented textbook names (R1, SW2, CR-01)?
+  * **completeness** — root cause, risk, verify phase, monitoring rules with
+    actual thresholds.
+
+The core is a deterministic heuristic (zero dependencies, CI-safe). Pass
+`use_llm=True` to blend in a real LLM judge via the configured provider —
+it degrades silently back to the heuristic when no LLM is reachable.
+
+CLI: `ai-log-analyzer eval` scores every playbook in the rule-based KB (a
+built-in quality self-test); `--file result.json` scores a saved
+/api/analyze result; `--min-score N` turns it into a CI gate.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from ai_log_analyzer import llm
+
+# Same placeholder pattern the analyzer scrubs — a playbook naming R1/SW2
+# instead of real inventory is hallucinating.
+_PLACEHOLDER_RE = re.compile(
+    r"\b(?:R[1-9]\d?|SW[1-9]\d?|CR-?\d+|BR-?\d+|"
+    r"spine-?[XYN]|leaf-?[XYN]|router-?[XYN]|switch-?[XYN])\b",
+    re.IGNORECASE,
+)
+
+# Disruptive commands that deserve surrounding context (a note, an expected
+# outcome, or a rollback) before an operator pastes them at 3am.
+_DISRUPTIVE_RE = re.compile(
+    r"\b(?:reload|reboot|restart\s+system|request\s+system\s+(?:reboot|halt)|"
+    r"clear\s+(?:bgp|ospf|ip\s+route)|shutdown|write\s+erase|format|"
+    r"delete\s+system)\b",
+    re.IGNORECASE,
+)
+
+_EXPECTED_PHASES = ("diagnose", "mitigate", "remediate", "verify", "optimize")
+
+
+def _clamp(x: float) -> float:
+    return round(max(0.0, min(10.0, x)), 1)
+
+
+def judge_playbook(deep: dict, devices: list[str] | None = None) -> dict[str, Any]:
+    """Score one deep-analysis playbook. Deterministic, no network."""
+    notes: list[str] = []
+    phases = deep.get("phases") or []
+    actions = [a for p in phases if isinstance(p, dict)
+               for a in (p.get("actions") or []) if isinstance(a, dict)]
+    clis = [c for a in actions for c in (a.get("cli") or {}).values() if c]
+
+    # actionability ─ phases + CLI density + preventive config
+    score = 0.0
+    phase_names = {str(p.get("name", "")).lower() for p in phases if isinstance(p, dict)}
+    score += 4.0 * (len(phase_names & set(_EXPECTED_PHASES)) / len(_EXPECTED_PHASES))
+    if clis:
+        score += 3.0
+        multi_platform = any(len(a.get("cli") or {}) >= 2 for a in actions)
+        if multi_platform:
+            score += 1.0
+    else:
+        notes.append("no CLI commands in any phase")
+    if deep.get("preventive_config"):
+        score += 1.0
+    if any(a.get("expected") for a in actions):
+        score += 1.0
+    actionability = _clamp(score)
+
+    # An empty playbook must not ace safety/grounding "by absence" — with no
+    # content to assess those dimensions are neutral, not perfect.
+    has_content = bool(clis or (deep.get("root_cause") or "").strip())
+
+    # safety ─ disruptive commands need context; secrets must not appear
+    score = 10.0 if has_content else 5.0
+    for a in actions:
+        for cli in (a.get("cli") or {}).values():
+            if cli and _DISRUPTIVE_RE.search(str(cli)):
+                if not (a.get("note") or a.get("expected")):
+                    score -= 3.0
+                    notes.append(f"disruptive command without context: {str(cli)[:60]}")
+                else:
+                    score -= 0.5
+    blob = json.dumps(deep)
+    if re.search(r"\$[169]\$[\w./$]{8,}", blob):
+        score -= 5.0
+        notes.append("playbook contains what looks like a password hash")
+    safety = _clamp(score)
+
+    # grounding ─ real hostnames in, placeholders out
+    score = 10.0 if has_content else 5.0
+    placeholder_hits = len(_PLACEHOLDER_RE.findall(blob))
+    if placeholder_hits:
+        real = {d.lower() for d in (devices or [])}
+        mentions_real = any(d and d in blob.lower() for d in real)
+        score -= min(placeholder_hits * 2.0, 6.0) * (0.5 if mentions_real else 1.0)
+        notes.append(f"{placeholder_hits} textbook placeholder name(s) (R1/SW2-style)")
+    if devices:
+        blob_lc = blob.lower()
+        if not any(d.lower() in blob_lc for d in devices):
+            score -= 2.0
+            notes.append("does not mention any affected device by name")
+    grounding = _clamp(score)
+
+    # completeness ─ root cause, risk, verify, monitoring with thresholds
+    score = 0.0
+    if (deep.get("root_cause") or "").strip():
+        score += 3.0
+    else:
+        notes.append("missing root_cause")
+    if (deep.get("risk") or "").strip():
+        score += 2.0
+    if "verify" in phase_names:
+        score += 2.0
+    monitoring = deep.get("monitoring") or []
+    if monitoring:
+        score += 1.5
+        if any(re.search(r"\d", str(m)) for m in monitoring):
+            score += 1.5  # thresholds are numbers, not vibes
+        else:
+            notes.append("monitoring rules carry no numeric thresholds")
+    completeness = _clamp(score)
+
+    overall = _clamp(
+        actionability * 0.35 + safety * 0.25 + grounding * 0.2 + completeness * 0.2
+    )
+    return {
+        "scores": {
+            "actionability": actionability,
+            "safety": safety,
+            "grounding": grounding,
+            "completeness": completeness,
+            "overall": overall,
+        },
+        "notes": notes[:8],
+        "judge": "heuristic",
+    }
+
+
+_LLM_JUDGE_PROMPT = """You are a strict senior NOC engineer reviewing an incident playbook.
+Score it 0-10 on: actionability (concrete runnable CLI), safety (disruptive
+steps have context/rollback), grounding (real device names, no invented ones),
+completeness (root cause, risk, verify steps, monitoring thresholds).
+Output STRICT JSON only: {"actionability": N, "safety": N, "grounding": N, "completeness": N}"""
+
+
+def judge_playbook_llm(deep: dict, devices: list[str] | None = None) -> dict[str, Any] | None:
+    """LLM pass — returns None when no provider is reachable or output is junk."""
+    if not llm.is_enabled():
+        return None
+    prompt = (f"AFFECTED DEVICES: {devices or ['unknown']}\n\n"
+              f"PLAYBOOK JSON:\n{json.dumps(deep, indent=1)[:6000]}\n\nScore it now.")
+    text = llm.query(_LLM_JUDGE_PROMPT, prompt, max_tokens=200)
+    if not text:
+        return None
+    try:
+        raw = json.loads(re.sub(r"^```[a-z]*\n?|\n?```$", "", text.strip()))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    dims = ("actionability", "safety", "grounding", "completeness")
+    try:
+        scores = {d: _clamp(float(raw[d])) for d in dims}
+    except (KeyError, TypeError, ValueError):
+        return None
+    scores["overall"] = _clamp(sum(scores[d] for d in dims) / 4)
+    return {"scores": scores, "notes": [], "judge": "llm"}
+
+
+def judge(deep: dict, devices: list[str] | None = None, use_llm: bool = False) -> dict[str, Any]:
+    """Heuristic verdict, blended 50/50 with the LLM's when one is available."""
+    heuristic = judge_playbook(deep, devices)
+    if not use_llm:
+        return heuristic
+    llm_verdict = judge_playbook_llm(deep, devices)
+    if llm_verdict is None:
+        return heuristic
+    blended = {
+        k: _clamp((heuristic["scores"][k] + llm_verdict["scores"][k]) / 2)
+        for k in heuristic["scores"]
+    }
+    return {"scores": blended, "notes": heuristic["notes"], "judge": "heuristic+llm"}
+
+
+def judge_analysis_result(result: dict, use_llm: bool = False) -> dict[str, Any]:
+    """Score every action item's playbook in a saved /api/analyze result."""
+    items = result.get("action_items") or []
+    verdicts = []
+    for item in items:
+        deep = item.get("deep_analysis") or {}
+        if not deep:
+            continue
+        v = judge(deep, devices=item.get("devices"), use_llm=use_llm)
+        verdicts.append({
+            "description": item.get("description", ""),
+            "severity": item.get("severity", ""),
+            **v,
+        })
+    overall = (round(sum(v["scores"]["overall"] for v in verdicts) / len(verdicts), 1)
+               if verdicts else 0.0)
+    return {"overall": overall, "playbooks_scored": len(verdicts), "verdicts": verdicts}
+
+
+def judge_kb(use_llm: bool = False) -> dict[str, Any]:
+    """Built-in self-test: score the rule-based KB's playbook for every
+    (category, description) the classifier can emit. This is the floor of
+    quality users get with the LLM off."""
+    from ai_log_analyzer import kb
+    from ai_log_analyzer.classifier import _KB_PATTERNS
+
+    seen: set[tuple[str, str]] = set()
+    verdicts = []
+    for _, severity, category, description in _KB_PATTERNS:
+        if severity not in ("critical", "high", "medium"):
+            continue
+        key = (category, description)
+        if key in seen:
+            continue
+        seen.add(key)
+        deep = kb.lookup(category, description)
+        v = judge(deep, use_llm=use_llm)
+        verdicts.append({"category": category, "description": description, **v})
+    verdicts.sort(key=lambda v: v["scores"]["overall"])
+    overall = (round(sum(v["scores"]["overall"] for v in verdicts) / len(verdicts), 1)
+               if verdicts else 0.0)
+    return {"overall": overall, "playbooks_scored": len(verdicts), "verdicts": verdicts}

--- a/src/ai_log_analyzer/stability.py
+++ b/src/ai_log_analyzer/stability.py
@@ -1,0 +1,225 @@
+"""Fabric stability scoring — flap detection, volume bursts, 24h risk forecast.
+
+Classified events tell you what broke; this module tells you what keeps
+breaking. It tracks, per device:
+
+  * **Flapping** — down→up→down oscillation of the same entity class
+    (interface, BGP peer, OSPF neighbor, LAG member, VPN tunnel). A link that
+    bounces six times an hour is a worse signal than one clean failure, but a
+    severity-ranked action list shows them the same way.
+  * **Volume bursts** — a device whose event rate spikes far above its own
+    baseline is misbehaving even when every individual event looks routine.
+  * **Trend** — whether a device's error activity is rising or falling across
+    the analysis window, projected into a deterministic 24h risk band.
+
+Everything is heuristic, streaming-safe (O(devices × entity classes) memory),
+and dependency-free. Timestamps in network logs are unreliable — mixed
+formats, missing entirely — so bucketing uses the minute prefix of whatever
+timestamp string exists and falls back to arrival order.
+"""
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from dataclasses import dataclass, field
+
+from ai_log_analyzer.classifier import ClassifiedEvent
+
+# Descriptions that represent an entity going DOWN / coming back UP.
+# Keyed by KB description (stable strings from the classifier), grouped into
+# an entity class so "BGP peer down" and "BGP peer established" pair up.
+_DOWN_DESCRIPTIONS: dict[str, str] = {
+    "Interface link down": "interface",
+    "BGP peer down / connect failure": "bgp",
+    "BGP peer idle / notification": "bgp",
+    "BGP notification / adjacency down (FRR/IOS)": "bgp",
+    "OSPF neighbor state change": "ospf",
+    "OSPF adjacency loss (FRR/IOS)": "ospf",
+    "BFD session down": "bfd",
+    "LACP/LAG member down": "lag",
+    "LAG member leaving bundle": "lag",
+    "VPN/IPsec tunnel failure": "vpn",
+    "VRRP/gateway failover": "redundancy",
+}
+_UP_DESCRIPTIONS: dict[str, str] = {
+    "Interface link up": "interface",
+    "BGP peer established": "bgp",
+    "OSPF neighbor established": "ospf",
+    "LAG member joining bundle": "lag",
+}
+
+_ENTITY_LABELS: dict[str, str] = {
+    "interface": "interface", "bgp": "BGP peer", "ospf": "OSPF neighbor",
+    "bfd": "BFD session", "lag": "LAG member", "vpn": "VPN tunnel",
+    "redundancy": "gateway redundancy",
+}
+
+# Strip trailing ":SS" / ":SS.mmm" so bucket keys have minute granularity.
+_SECONDS_RE = re.compile(r":\d{2}(?:[.,]\d+)?\s*(?:Z|[+-]\d{2}:?\d{2})?$")
+
+_MAX_BUCKETS_PER_HOST = 512
+_ARRIVAL_BUCKET_SIZE = 200  # events per synthetic bucket when no timestamp
+
+
+@dataclass
+class _DeviceState:
+    transitions: dict[str, int] = field(default_factory=dict)   # entity → down↔up flips
+    last_state: dict[str, str] = field(default_factory=dict)    # entity → "down"|"up"
+    downs: dict[str, int] = field(default_factory=dict)         # entity → down events
+    criticals: int = 0
+    highs: int = 0
+    total: int = 0
+    buckets: OrderedDict[str, int] = field(default_factory=OrderedDict)  # minute → count
+
+
+class StabilityTracker:
+    """Single-pass stability aggregator — feed every classified event."""
+
+    def __init__(self) -> None:
+        self._devices: dict[str, _DeviceState] = {}
+        self._seq = 0
+
+    def add(self, e: ClassifiedEvent) -> None:
+        if not e.hostname:
+            return
+        st = self._devices.setdefault(e.hostname, _DeviceState())
+        st.total += 1
+        if e.severity == "critical":
+            st.criticals += 1
+        elif e.severity == "high":
+            st.highs += 1
+
+        entity = _DOWN_DESCRIPTIONS.get(e.description)
+        if entity is not None:
+            st.downs[entity] = st.downs.get(entity, 0) + 1
+            if st.last_state.get(entity) == "up":
+                st.transitions[entity] = st.transitions.get(entity, 0) + 1
+            st.last_state[entity] = "down"
+        else:
+            entity = _UP_DESCRIPTIONS.get(e.description)
+            if entity is not None:
+                if st.last_state.get(entity) == "down":
+                    st.transitions[entity] = st.transitions.get(entity, 0) + 1
+                st.last_state[entity] = "up"
+
+        # Minute-granularity bucket; arrival-order fallback for blank stamps.
+        ts = e.timestamp or ""
+        key = _SECONDS_RE.sub("", ts) if ts else f"seq-{self._seq // _ARRIVAL_BUCKET_SIZE}"
+        st.buckets[key] = st.buckets.get(key, 0) + 1
+        st.buckets.move_to_end(key)
+        while len(st.buckets) > _MAX_BUCKETS_PER_HOST:
+            st.buckets.popitem(last=False)
+        self._seq += 1
+
+    # ── report ────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _flap_count(st: _DeviceState) -> int:
+        """Full flaps = completed down↔up round trips across all entities."""
+        return sum(t // 2 for t in st.transitions.values())
+
+    @staticmethod
+    def _burst_ratio(st: _DeviceState) -> float:
+        """Peak minute vs the device's own median minute (≥1.0)."""
+        counts = sorted(st.buckets.values())
+        if len(counts) < 3:
+            return 1.0
+        median = counts[len(counts) // 2] or 1
+        return round(counts[-1] / median, 1)
+
+    @staticmethod
+    def _trend(st: _DeviceState) -> str:
+        """Rising/stable/falling error activity across the window halves."""
+        counts = list(st.buckets.values())
+        if len(counts) < 4:
+            return "stable"
+        half = len(counts) // 2
+        first, second = sum(counts[:half]) or 1, sum(counts[half:])
+        ratio = second / first
+        if ratio >= 1.5:
+            return "rising"
+        if ratio <= 0.67:
+            return "falling"
+        return "stable"
+
+    @staticmethod
+    def _score(st: _DeviceState, flaps: int, burst: float) -> int:
+        score = 100
+        score -= min(flaps * 6, 35)
+        score -= min(st.criticals * 5, 25)
+        score -= min(st.highs * 1, 15)
+        if burst >= 10:
+            score -= 20
+        elif burst >= 5:
+            score -= 12
+        elif burst >= 3:
+            score -= 6
+        return max(0, score)
+
+    @staticmethod
+    def _risk(score: int, trend: str) -> str:
+        if score < 50 or (score < 70 and trend == "rising"):
+            return "high"
+        if score < 70 or trend == "rising":
+            return "medium"
+        return "low"
+
+    def report(self, top_n: int = 20) -> dict:
+        """JSON-ready stability report: per-device scores, worst first."""
+        devices: list[dict] = []
+        for host, st in self._devices.items():
+            flaps = self._flap_count(st)
+            burst = self._burst_ratio(st)
+            trend = self._trend(st)
+            score = self._score(st, flaps, burst)
+            worst_entity = max(st.transitions, key=st.transitions.get) if st.transitions else ""
+            devices.append({
+                "hostname": host,
+                "score": score,
+                "flaps": flaps,
+                "flapping_entity": _ENTITY_LABELS.get(worst_entity, worst_entity),
+                "criticals": st.criticals,
+                "highs": st.highs,
+                "events": st.total,
+                "burst_ratio": burst,
+                "trend": trend,
+                "risk_24h": self._risk(score, trend),
+            })
+        devices.sort(key=lambda d: (d["score"], -d["flaps"]))
+
+        if devices:
+            # Weight by event volume so one noisy core drags more than a quiet leaf.
+            total_events = sum(d["events"] for d in devices) or 1
+            fabric = round(sum(d["score"] * d["events"] for d in devices) / total_events)
+        else:
+            fabric = 100
+
+        return {
+            "fabric_score": fabric,
+            "device_count": len(devices),
+            "devices": devices[:top_n],
+            "recommendations": _recommendations(devices),
+        }
+
+
+def _recommendations(devices: list[dict]) -> list[str]:
+    recs: list[str] = []
+    for d in devices:
+        if d["flaps"] >= 2 and d["flapping_entity"]:
+            recs.append(
+                f"{d['hostname']}: {d['flapping_entity']} flapped {d['flaps']}× — "
+                f"dampen or fix the underlying link before it pages again"
+            )
+        if d["risk_24h"] == "high":
+            recs.append(
+                f"{d['hostname']}: high 24h risk (score {d['score']}, {d['trend']} trend) — "
+                f"prioritize in the current shift"
+            )
+        if d["burst_ratio"] >= 5:
+            recs.append(
+                f"{d['hostname']}: event rate spiked {d['burst_ratio']}× above its median "
+                f"minute — check for a rolling condition"
+            )
+        if len(recs) >= 8:
+            break
+    return recs[:8]

--- a/src/ai_log_analyzer/web/static/app.js
+++ b/src/ai_log_analyzer/web/static/app.js
@@ -770,6 +770,39 @@ function render(r) {
     aTbody.appendChild(tr);
   });
 
+  // Fabric stability (flaps, bursts, 24h risk)
+  const stab = r.stability || {};
+  const stabPanel = $("stability-panel");
+  if (stabPanel) {
+    const devs = stab.devices || [];
+    if (devs.length) {
+      stabPanel.style.display = "block";
+      $("stability-score").textContent = `(fabric ${stab.fabric_score}/100 · ${stab.device_count} devices)`;
+      const sTbody = $("stability-table").querySelector("tbody");
+      clear(sTbody);
+      devs.slice(0, 15).forEach((d) => {
+        const riskClass = d.risk_24h === "high" ? "sev-row-critical"
+          : d.risk_24h === "medium" ? "sev-row-medium" : "";
+        const flapLabel = d.flaps
+          ? `${d.flaps}× ${d.flapping_entity || ""}`.trim() : "—";
+        const trendIcon = d.trend === "rising" ? "↗" : d.trend === "falling" ? "↘" : "→";
+        sTbody.appendChild(el("tr", { className: riskClass },
+          el("td", { text: d.hostname }),
+          el("td", { text: String(d.score) }),
+          el("td", { text: flapLabel }),
+          el("td", { text: d.burst_ratio > 1 ? `${d.burst_ratio}×` : "—" }),
+          el("td", { text: `${trendIcon} ${d.trend}` }),
+          el("td", { text: d.risk_24h.toUpperCase() }),
+        ));
+      });
+      const recs = $("stability-recs");
+      clear(recs);
+      (stab.recommendations || []).forEach((t) => recs.appendChild(el("li", { text: t })));
+    } else {
+      stabPanel.style.display = "none";
+    }
+  }
+
   // Unknown patterns (mined templates of lines no KB rule matched)
   const up = r.unknown_patterns || {};
   const upTemplates = up.top_templates || [];

--- a/src/ai_log_analyzer/web/static/index.html
+++ b/src/ai_log_analyzer/web/static/index.html
@@ -232,6 +232,7 @@
   #summary-panel         { contain-intrinsic-size: 0 260px; }
   #actions-panel         { contain-intrinsic-size: 0 380px; }
   #unknown-panel         { contain-intrinsic-size: 0 300px; }
+  #stability-panel       { contain-intrinsic-size: 0 340px; }
   #events-panel          { contain-intrinsic-size: 0 540px; }
   #optimize-panel        { contain-intrinsic-size: 0 800px; }
   #site-panel            { contain-intrinsic-size: 0 720px; }
@@ -1435,6 +1436,18 @@
         </thead>
         <tbody></tbody>
       </table>
+    </div>
+
+    <div class="panel" id="stability-panel" style="display:none;">
+      <h2>📶 Fabric Stability <span class="h2-count" id="stability-score"></span></h2>
+      <p class="row-msg" style="margin:0 0 8px;">Per-device stability: flap oscillations (down↔up round trips), event-rate bursts vs the device's own baseline, and a heuristic 24h risk band from the activity trend. Worst devices first.</p>
+      <table id="stability-table">
+        <thead>
+          <tr><th>Device</th><th>Score</th><th>Flaps</th><th>Burst</th><th>Trend</th><th>24h Risk</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <ul class="summary" id="stability-recs" style="margin-top:8px;"></ul>
     </div>
 
     <div class="panel" id="unknown-panel" style="display:none;">

--- a/tests/test_stability_judge.py
+++ b/tests/test_stability_judge.py
@@ -1,0 +1,197 @@
+"""Tests for the fabric stability engine (stability.py) and the
+LLM-as-Judge playbook scorer (judge.py) + its CLI command."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai_log_analyzer import judge
+from ai_log_analyzer.classifier import LogEvent, iter_classify
+from ai_log_analyzer.stability import StabilityTracker
+
+
+pytestmark = pytest.mark.unit
+
+
+def _events(lines: list[tuple[str, str, str]]):
+    """(timestamp, host, message) → classified events."""
+    return iter_classify(
+        LogEvent(timestamp=ts, hostname=h, appname="rpd", severity_raw="info", message=m)
+        for ts, h, m in lines
+    )
+
+
+# ── stability: flap detection ────────────────────────────────────────────────
+
+def test_flapping_interface_detected_and_scored():
+    lines = []
+    for i in range(6):  # 3 full down→up→down… cycles on r1
+        state = "snmp_trap_link_down" if i % 2 == 0 else "snmp_trap_link_up"
+        lines.append((f"Jan  1 00:0{i}:00", "r1", f"{state} ifIndex 501 ge-0/0/1"))
+    lines.append(("Jan  1 00:07:00", "r2", "bgp peer 10.0.0.1 down hold timer"))
+
+    tracker = StabilityTracker()
+    for e in _events(lines):
+        tracker.add(e)
+    report = tracker.report()
+
+    r1 = next(d for d in report["devices"] if d["hostname"] == "r1")
+    assert r1["flaps"] >= 2
+    assert r1["flapping_entity"] == "interface"
+    r2 = next(d for d in report["devices"] if d["hostname"] == "r2")
+    assert r2["flaps"] == 0          # one clean failure is not a flap
+    assert r1["score"] < r2["score"]  # flapping is worse than one incident
+    assert any("flapped" in r for r in report["recommendations"])
+
+
+def test_stable_device_scores_high_low_risk():
+    lines = [(f"Jan  1 00:00:{i:02d}", "sw-1", f"sshd session opened for user ops{i}")
+             for i in range(10)]
+    tracker = StabilityTracker()
+    for e in _events(lines):
+        tracker.add(e)
+    d = tracker.report()["devices"][0]
+    assert d["score"] >= 90
+    assert d["risk_24h"] == "low"
+    assert d["trend"] == "stable"
+
+
+def test_rising_trend_and_risk_band():
+    # Quiet early minutes, busy late minutes → rising trend.
+    lines = [(f"Jan  1 00:0{m}:00", "core-1", "bgp peer 10.0.0.9 down hold timer")
+             for m in (1, 2, 3, 4)]
+    lines += [(f"Jan  1 00:0{m}:{s:02d}", "core-1", "bgp peer 10.0.0.9 down hold timer")
+              for m in (5, 6) for s in range(0, 50, 10)]
+    tracker = StabilityTracker()
+    for e in _events(lines):
+        tracker.add(e)
+    d = tracker.report()["devices"][0]
+    assert d["trend"] == "rising"
+    assert d["risk_24h"] in ("medium", "high")
+
+
+def test_empty_input_reports_perfect_fabric():
+    report = StabilityTracker().report()
+    assert report == {"fabric_score": 100, "device_count": 0,
+                      "devices": [], "recommendations": []}
+
+
+def test_analyze_carries_stability_section():
+    from ai_log_analyzer.analyzer import analyze
+    events = [LogEvent(timestamp="Jan  1 00:00:01", hostname="r1", appname="rpd",
+                       severity_raw="err", message="bgp peer 10.0.0.1 down")]
+    result = analyze(iter(events), use_llm=False)
+    stab = result.to_dict()["stability"]
+    assert stab["device_count"] == 1
+    assert stab["devices"][0]["hostname"] == "r1"
+
+
+# ── judge: heuristic scoring ─────────────────────────────────────────────────
+
+GOOD_PLAYBOOK = {
+    "root_cause": "BGP hold timer expired due to intermittent L1 errors on the peering link.",
+    "risk": "Peer flaps withdraw 40k prefixes each cycle, causing reconvergence spikes.",
+    "phases": [
+        {"name": n, "goal": "g", "actions": [
+            {"cli": {"junos": "show bgp summary", "eos": "show ip bgp summary"},
+             "expected": "peer Established > 1h", "note": "check both ends"},
+        ]} for n in ("Diagnose", "Mitigate", "Remediate", "Verify", "Optimize")
+    ],
+    "preventive_config": ["set protocols bgp group isp bfd-liveness-detection minimum-interval 300"],
+    "monitoring": ["Alert when BGP session state != Established for > 30 seconds"],
+    "timeline": "P2",
+}
+
+EMPTY_PLAYBOOK = {"root_cause": "", "risk": "", "phases": [], "preventive_config": [], "monitoring": []}
+
+
+def test_good_playbook_outscores_empty():
+    good = judge.judge_playbook(GOOD_PLAYBOOK, devices=["core-1"])
+    bad = judge.judge_playbook(EMPTY_PLAYBOOK)
+    assert good["scores"]["overall"] >= 7
+    assert bad["scores"]["overall"] <= 3
+    assert "missing root_cause" in " ".join(bad["notes"])
+
+
+def test_disruptive_command_without_context_penalized():
+    risky = dict(GOOD_PLAYBOOK)
+    risky["phases"] = [{"name": "Mitigate", "goal": "g", "actions": [
+        {"cli": {"junos": "request system reboot"}, "expected": "", "note": ""},
+    ]}]
+    v = judge.judge_playbook(risky, devices=["core-1"])
+    assert v["scores"]["safety"] <= 7
+    assert any("disruptive" in n for n in v["notes"])
+
+
+def test_placeholder_names_hurt_grounding():
+    hallucinated = dict(GOOD_PLAYBOOK)
+    hallucinated["root_cause"] = "R1 and SW2 have mismatched timers"
+    v = judge.judge_playbook(hallucinated, devices=["core-1"])
+    grounded = judge.judge_playbook(GOOD_PLAYBOOK, devices=["core-1"])
+    assert v["scores"]["grounding"] < grounded["scores"]["grounding"]
+
+
+def test_judge_kb_self_test_scores_every_actionable_rule():
+    report = judge.judge_kb()
+    assert report["playbooks_scored"] > 20
+    assert 0 < report["overall"] <= 10
+    # every verdict has the full score set
+    for v in report["verdicts"]:
+        assert set(v["scores"]) == {"actionability", "safety", "grounding",
+                                    "completeness", "overall"}
+
+
+def test_judge_llm_blend_falls_back_when_llm_dead(monkeypatch):
+    from ai_log_analyzer import llm
+    monkeypatch.setattr(llm, "is_enabled", lambda: True)
+    monkeypatch.setattr(llm, "query", lambda *a, **k: None)  # provider dead
+    v = judge.judge(GOOD_PLAYBOOK, use_llm=True)
+    assert v["judge"] == "heuristic"
+
+
+def test_judge_llm_blend_merges_scores(monkeypatch):
+    from ai_log_analyzer import llm
+    monkeypatch.setattr(llm, "is_enabled", lambda: True)
+    monkeypatch.setattr(llm, "query", lambda *a, **k: json.dumps(
+        {"actionability": 10, "safety": 10, "grounding": 10, "completeness": 10}))
+    v = judge.judge(EMPTY_PLAYBOOK, use_llm=True)
+    assert v["judge"] == "heuristic+llm"
+    heuristic_only = judge.judge_playbook(EMPTY_PLAYBOOK)
+    assert v["scores"]["overall"] > heuristic_only["scores"]["overall"]
+
+
+# ── eval CLI ─────────────────────────────────────────────────────────────────
+
+def test_cli_eval_kb_self_test(capsys):
+    from ai_log_analyzer.cli import main
+    import sys as _sys
+    argv = _sys.argv
+    _sys.argv = ["ai-log-analyzer", "eval", "--json"]
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+    finally:
+        _sys.argv = argv
+    report = json.loads(capsys.readouterr().out)
+    assert report["playbooks_scored"] > 20
+
+
+def test_cli_eval_min_score_gate(tmp_path, capsys):
+    from ai_log_analyzer.cli import main
+    import sys as _sys
+    bad_result = {"action_items": [
+        {"description": "x", "severity": "high", "devices": [],
+         "deep_analysis": EMPTY_PLAYBOOK},
+    ]}
+    f = tmp_path / "result.json"
+    f.write_text(json.dumps(bad_result))
+    argv = _sys.argv
+    _sys.argv = ["ai-log-analyzer", "eval", "--file", str(f), "--min-score", "9.9"]
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1  # CI gate trips
+    finally:
+        _sys.argv = argv

--- a/tests/test_streaming_analyze.py
+++ b/tests/test_streaming_analyze.py
@@ -76,7 +76,7 @@ def test_aggregate_stream_is_bounded():
                 message=f"job {i} completed",
             )
 
-    top, sev, cat, groups, by_host, miner = _aggregate_stream(iter_classify(synth(20_000)), top_k=300)
+    top, sev, cat, groups, by_host, miner, tracker = _aggregate_stream(iter_classify(synth(20_000)), top_k=300)
     assert sev["info"] == 20_000
     assert len(top) <= 300
     assert len(by_host) == 7
@@ -84,6 +84,10 @@ def test_aggregate_stream_is_bounded():
     # 20k unmatched lines share one shape once numbers are masked → 1 template
     assert miner.cluster_count <= 2
     assert miner.to_dict()["total_unclassified"] == 20_000
+    # stability tracker stays bounded too: 7 hosts, capped buckets each
+    report = tracker.report()
+    assert report["device_count"] == 7
+    assert all(len(s.buckets) <= 512 for s in tracker._devices.values())
 
 
 # ── web size guard + generator path ─────────────────────────────────────────


### PR DESCRIPTION
## Why

Builds the real, verified version of the "Phase 12" feature set that previously existed only as text in an unexported chat session — implemented natively on current `main` so it composes with the streaming pipeline, sanitize gate, and template miner already there.

## 📶 Fabric stability engine (`stability.py`)

Classified events tell you what broke; this tells you what *keeps* breaking:

- **Flap detection** — down↔up oscillation of the same entity class per device (interfaces, BGP peers, OSPF neighbors, BFD sessions, LAG members, VPN tunnels). Three bounces score far worse than one clean failure, which a severity-ranked list can't express.
- **Volume bursts** — peak-minute event rate vs the device's *own* median minute.
- **Trend + 24h risk band** — rising/stable/falling activity across the window, projected into a deterministic low/medium/high risk band.
- Wired into `analyze()`'s single streaming pass: O(devices × entity classes) memory, minute-prefix bucketing with arrival-order fallback (network syslog timestamps are unreliable and sometimes absent).
- Surfaces as `stability` in `/api/analyze` + MCP `analyze_logs`, and as a **Fabric Stability** UI panel (worst devices first, plain-language recommendations).

## ⚖️ LLM-as-Judge playbook scoring (`judge.py` + `ai-log-analyzer eval`)

The product's core output is LLM/KB-generated remediation playbooks — nothing measured their quality until now:

- Scores 0–10 on **actionability** (real runnable CLI, expected outputs, preventive config), **safety** (disruptive commands need context; empty playbooks can't ace safety "by absence"), **grounding** (real device names in, R1/SW2-style placeholders out), **completeness** (root cause, risk, verify phase, monitoring rules with numeric thresholds).
- Deterministic heuristic core (zero deps, CI-safe); `--use-llm` blends a real LLM judge through the configured provider chain with silent fallback.
- `ai-log-analyzer eval` self-tests all 41 actionable KB playbooks by default (currently 9.8/10 overall — the quality floor with the LLM off), scores a saved `/api/analyze` result with `--file`, and `--min-score N` turns it into a CI quality gate.

## Version

0.3.1 → **0.4.0** (this plus the merged PR #12 feature set makes an honest minor release; the CHANGELOG `Unreleased` section is now the 0.4.0 entry).

## Tests

325 → **338 passed** (2 skipped), ruff clean. New coverage: flap/burst/trend/risk scoring, bounded-memory guarantee, analyze integration, judge scoring semantics (good vs empty, disruptive-command penalty, placeholder penalty), LLM-blend fallback + merge, and both `eval` CLI paths including the CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XM7j9iDXYwSvjnxZYjzaq

---
_Generated by [Claude Code](https://claude.ai/code/session_015XM7j9iDXYwSvjnxZYjzaq)_