### PR TITLE
chore: add Copilot custom instructions and coding-agent setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,59 @@
+# netlog-ai
+
+AI-powered network log analyzer with LLM-assisted root-cause analysis for Junos, EOS, and FRR. Runs against a local Docker Model Runner or Anthropic Claude, and sanitizes log content before it reaches any model. MIT licensed, published to PyPI.
+
+**Stack.** Python >=3.10, packaged via `pyproject.toml`. Docker + docker-compose. JS front end.
+
+**Layout.** `src/` package, `demo/`, `scripts/`, `tests/`, `docs/`
+
+## Build and test
+
+```bash
+python -m pip install --upgrade pip
+pip install -e '.[dev]' || { pip install -e .; pip install pytest pytest-cov ruff; }
+python -m pytest -q
+```
+
+Run the tests before proposing a change is done. If you cannot run them, say so explicitly
+rather than claiming the change is verified.
+
+## Engineering conventions (non-negotiable)
+
+- **Type hints on every function signature.** No bare `def f(x):`.
+- **async/await for all I/O.** Never block the event loop with sync network or disk calls.
+- **Immutable data.** Return new objects; do not mutate arguments in place.
+- **Tests first.** Write the failing test, watch it fail, then implement. Target 80%+ coverage.
+- **Small files.** 200-400 lines typical, 800 hard max. Extract modules rather than growing a file.
+- **Small functions.** Under 50 lines. Nesting no deeper than 4 levels - use early returns.
+- **Handle every error explicitly.** Never swallow an exception silently. Log context server-side,
+  return a friendly message user-side.
+- **Validate at boundaries.** Never trust user input, API responses, or file contents.
+- **No hardcoded secrets, ever.** Environment variables or a secret manager only. No credentials
+  in code, comments, logs, tests, or fixtures.
+- **Conventional Commits**: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`.
+  Imperative mood, lower case, no trailing period. Do **not** add `Co-authored-by` trailers.
+
+## Before you propose a change
+
+1. Read the surrounding code and match its idiom, naming, and comment density.
+2. Prefer a battle-tested library over hand-rolled utility code.
+3. If you touch auth, user input, DB queries, file paths, or external calls, re-read the
+   security rules above before finishing.
+
+## Public repo + published package - extra care
+
+- **Sanitize before LLM is the core guarantee.** Any new code path that sends log content to a
+  model must route through the existing sanitizer. Never add a "raw" or "skip-sanitize" mode.
+  Log lines carry IPs, hostnames, ASNs, community strings, and occasionally credentials.
+- This is a **public MIT repo published to PyPI**. Nothing internal, customer-identifying, or
+  employer-specific may appear in code, tests, fixtures, docs, or commit messages.
+- Test fixtures must use RFC 5737 / RFC 3849 documentation addresses and obviously fake
+  hostnames - never real captured device output.
+- Keep `CHANGELOG.md` current; releases are cut from it via `release.yml`.
+- Public API changes need a version bump and a CHANGELOG entry in the same PR.
+
+## Pull requests
+
+- Title in Conventional Commits form.
+- Body covers: what changed, why, blast radius, and a test plan as a checklist.
+- Summarise the whole commit range, not just the last commit.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,8 @@
 # netlog-ai
 
-AI-powered network log analyzer with LLM-assisted root-cause analysis for Junos, EOS, and FRR. Runs against a local Docker Model Runner or Anthropic Claude, and sanitizes log content before it reaches any model. MIT licensed, published to PyPI.
+AI-powered network log analyzer with LLM-assisted root-cause analysis for Junos, EOS, and FRR.
+Runs against a local Docker Model Runner or Anthropic Claude, and sanitizes log content before
+it reaches any model. MIT licensed, published to PyPI.
 
 **Stack.** Python >=3.10, packaged via `pyproject.toml`. Docker + docker-compose. JS front end.
 
@@ -10,39 +12,31 @@ AI-powered network log analyzer with LLM-assisted root-cause analysis for Junos,
 
 ```bash
 python -m pip install --upgrade pip
-pip install -e '.[dev]' || { pip install -e .; pip install pytest pytest-cov ruff; }
+python -m pip install -e '.[dev]'
 python -m pytest -q
 ```
 
-Run the tests before proposing a change is done. If you cannot run them, say so explicitly
-rather than claiming the change is verified.
+Note: the `parse` and `all` extras pin `tfsm-fire`, which is **not published on PyPI**. Install
+the `dev` extra for development; `.[all,dev]` currently fails to resolve.
 
 ## Engineering conventions (non-negotiable)
 
 - **Type hints on every function signature.** No bare `def f(x):`.
-- **async/await for all I/O.** Never block the event loop with sync network or disk calls.
+- **async/await for I/O** in async code paths. Never block an event loop with a sync call.
 - **Immutable data.** Return new objects; do not mutate arguments in place.
 - **Tests first.** Write the failing test, watch it fail, then implement. Target 80%+ coverage.
 - **Small files.** 200-400 lines typical, 800 hard max. Extract modules rather than growing a file.
 - **Small functions.** Under 50 lines. Nesting no deeper than 4 levels - use early returns.
-- **Handle every error explicitly.** Never swallow an exception silently. Log context server-side,
-  return a friendly message user-side.
+- **Handle every error explicitly.** Never swallow an exception silently.
 - **Validate at boundaries.** Never trust user input, API responses, or file contents.
 - **No hardcoded secrets, ever.** Environment variables or a secret manager only. No credentials
   in code, comments, logs, tests, or fixtures.
 - **Conventional Commits**: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`.
   Imperative mood, lower case, no trailing period. Do **not** add `Co-authored-by` trailers.
 
-## Before you propose a change
-
-1. Read the surrounding code and match its idiom, naming, and comment density.
-2. Prefer a battle-tested library over hand-rolled utility code.
-3. If you touch auth, user input, DB queries, file paths, or external calls, re-read the
-   security rules above before finishing.
-
 ## Public repo + published package - extra care
 
-- **Sanitize before LLM is the core guarantee.** Any new code path that sends log content to a
+- **Sanitize before LLM is the core guarantee.** Any new code path sending log content to a
   model must route through the existing sanitizer. Never add a "raw" or "skip-sanitize" mode.
   Log lines carry IPs, hostnames, ASNs, community strings, and occasionally credentials.
 - This is a **public MIT repo published to PyPI**. Nothing internal, customer-identifying, or
@@ -56,4 +50,3 @@ rather than claiming the change is verified.
 
 - Title in Conventional Commits form.
 - Body covers: what changed, why, blast radius, and a test plan as a checklist.
-- Summarise the whole commit range, not just the last commit.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**/*.py"
+---
+
+# Python
+
+- Target the repo's declared `requires-python`. Do not use syntax newer than that.
+- Full type annotations, including return types. Use `from __future__ import annotations`
+  where it keeps signatures readable.
+- Prefer `pathlib.Path` over `os.path`, f-strings over `%`/`.format()`,
+  `dataclasses`/`pydantic` over ad-hoc dicts for structured data.
+- Use `httpx.AsyncClient` (or the repo's existing async client) for HTTP. Never `requests`
+  inside async code.
+- Exceptions: raise specific types, never bare `except:`. `except Exception` requires a
+  logged reason and a comment explaining why it is safe to continue.
+- Immutability: return new lists/dicts/dataclasses rather than mutating inputs.
+  `dataclasses.replace()` and `{**old, "k": v}` are preferred over in-place edits.
+- Logging: module-level `logger = logging.getLogger(__name__)`. Never `print()` in library code.
+  Never log secrets, tokens, or personally identifying data.
+- Run `ruff check --fix` and `ruff format` on anything you touch.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -4,13 +4,12 @@ applyTo: "**/*.py"
 
 # Python
 
-- Target the repo's declared `requires-python`. Do not use syntax newer than that.
+- Target `requires-python = ">=3.10"`. CI matrixes 3.10/3.11/3.12, so do not use syntax newer than 3.10.
 - Full type annotations, including return types. Use `from __future__ import annotations`
   where it keeps signatures readable.
 - Prefer `pathlib.Path` over `os.path`, f-strings over `%`/`.format()`,
-  `dataclasses`/`pydantic` over ad-hoc dicts for structured data.
-- Use `httpx.AsyncClient` (or the repo's existing async client) for HTTP. Never `requests`
-  inside async code.
+  `dataclasses` over ad-hoc dicts for structured data.
+- Match the HTTP client already used in the module you are editing. Do not introduce a new HTTP dependency without raising it in the PR.
 - Exceptions: raise specific types, never bare `except:`. `except Exception` requires a
   logged reason and a comment explaining why it is safe to continue.
 - Immutability: return new lists/dicts/dataclasses rather than mutating inputs.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -10,7 +10,8 @@ applyTo: "tests/**"
 - Every bug fix starts with a regression test that fails before the fix.
 - Cover the error paths, not just the happy path: bad input, network failure, empty result,
   boundary values.
-- Never hit the live network. Mock at the client boundary with `respx`, `responses`,
-  or `monkeypatch`.
-- Tests must be order-independent and safe to run with `pytest -n auto`.
+- Never hit the live network. Mock at the client boundary using `monkeypatch` or
+  `unittest.mock` - both are already available. Do not add a new mocking dependency
+  without raising it in the PR first.
+- Tests must be order-independent. Do not assume execution order or shared mutable state.
 - No secrets or real credentials in fixtures - use obviously fake values.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "tests/**"
+---
+
+# Tests
+
+- pytest only. No `unittest.TestCase` classes in new code.
+- Name tests `test_<unit>_<scenario>_<expected>` so failures read as sentences.
+- Prefer fixtures over setup/teardown methods; prefer `@pytest.mark.parametrize` over loops.
+- Every bug fix starts with a regression test that fails before the fix.
+- Cover the error paths, not just the happy path: bad input, network failure, empty result,
+  boundary values.
+- Never hit the live network. Mock at the client boundary with `respx`, `responses`,
+  or `monkeypatch`.
+- Tests must be order-independent and safe to run with `pytest -n auto`.
+- No secrets or real credentials in fixtures - use obviously fake values.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -1,0 +1,19 @@
+---
+mode: agent
+description: Security and quality review of the current changes
+---
+
+Review the current diff (`git diff` plus staged changes) and report findings ordered by severity.
+
+Check, in this order:
+
+1. **Secrets** - hardcoded keys, tokens, passwords, connection strings, in code *or* tests.
+2. **Injection** - SQL/shell/path built by string concatenation from untrusted input.
+3. **Boundary validation** - external input used without validation.
+4. **Error handling** - swallowed exceptions, bare `except`, missing failure paths.
+5. **Mutation** - functions that modify their arguments in place.
+6. **Size** - functions over 50 lines, files over 800 lines, nesting deeper than 4.
+7. **Test coverage** - new behaviour with no accompanying test.
+
+For each finding give: `file:line`, severity (CRITICAL/HIGH/MEDIUM/LOW), the concrete failure
+scenario, and the minimal fix. If a category is clean, say so in one line - do not pad the report.

--- a/.github/prompts/tdd.prompt.md
+++ b/.github/prompts/tdd.prompt.md
@@ -3,9 +3,9 @@ mode: agent
 description: Write failing tests first for a change (TDD)
 ---
 
-Practise strict TDD for the change I describe.
+Practice strict TDD for the change I describe.
 
-1. Restate the behaviour in one sentence.
+1. Restate the behavior in one sentence.
 2. Write the tests **first**, covering happy path, boundaries, and error paths.
 3. Run them and show me they fail for the right reason - not an import or syntax error.
 4. Write the minimum implementation to make them pass.

--- a/.github/prompts/tdd.prompt.md
+++ b/.github/prompts/tdd.prompt.md
@@ -1,0 +1,15 @@
+---
+mode: agent
+description: Write failing tests first for a change (TDD)
+---
+
+Practise strict TDD for the change I describe.
+
+1. Restate the behaviour in one sentence.
+2. Write the tests **first**, covering happy path, boundaries, and error paths.
+3. Run them and show me they fail for the right reason - not an import or syntax error.
+4. Write the minimum implementation to make them pass.
+5. Run the full suite and report coverage for the touched module.
+6. Refactor only once green, re-running tests after each step.
+
+Do not write implementation code before step 3 has actually been executed.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,16 +1,16 @@
 # Environment preparation for the GitHub Copilot coding agent.
 #
-# The agent runs ONLY the job named `copilot-setup-steps` from this file before it
-# starts work, so dependencies are already installed when it opens a PR.
+# The agent runs ONLY the job named `copilot-setup-steps` before it starts work,
+# so dependencies are already installed when it opens a PR.
 # https://docs.github.com/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+#
+# Deliberately NO `pull_request` trigger: a fork PR editing this file would
+# otherwise execute untrusted code on our runner.
 name: Copilot Setup Steps
 
 on:
   workflow_dispatch:
   push:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
-  pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
@@ -26,11 +26,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev]' || { pip install -e .; pip install pytest pytest-cov ruff; }
+          # NOT '.[all,dev]': the 'all' extra pins tfsm-fire, which is not on PyPI.
+          python -m pip install -e '.[dev]'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,36 @@
+# Environment preparation for the GitHub Copilot coding agent.
+#
+# The agent runs ONLY the job named `copilot-setup-steps` from this file before it
+# starts work, so dependencies are already installed when it opens a PR.
+# https://docs.github.com/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]' || { pip install -e .; pip install pytest pytest-cov ruff; }


### PR DESCRIPTION
## What

Adds GitHub Copilot repo configuration so Copilot has real project context instead of
guessing from open files.

| File | Purpose |
|---|---|
| `.github/copilot-instructions.md` | Repo-wide: what this is, stack, layout, build/test commands, engineering conventions, repo-specific gotchas |
| `.github/instructions/*.instructions.md` | Path-scoped rules applied automatically via `applyTo` globs |
| `.github/prompts/*.prompt.md` | Reusable prompts — `/review` (security + quality) and `/tdd` |
| `.github/workflows/copilot-setup-steps.yml` | Preinstalls dependencies for the Copilot **coding agent**, so it can run tests when working on an assigned issue |

## Why

These files are read by Copilot across every surface — Chat and inline in VS Code, the Copilot
coding agent on github.com, Copilot code review on PRs, and the Copilot CLI. Without them each
surface re-derives context from scratch and drifts from the conventions used here.

## Blast radius

Documentation and one workflow. **No application code is touched.**

The new workflow only triggers on `workflow_dispatch` and on changes to itself, so it does not
run on normal pushes or PRs and cannot affect existing CI.

## Test plan

- [ ] `.github/workflows/copilot-setup-steps.yml` parses (validated locally with PyYAML; job is named `copilot-setup-steps` as the agent requires)
- [ ] Run the workflow once via **Actions → Copilot Setup Steps → Run workflow** to confirm dependencies install cleanly
- [ ] Open Copilot Chat in this repo and confirm it cites `copilot-instructions.md`
- [ ] Existing CI unaffected (no changes to `ci.yml` / `tests.yml`)
