### PR TITLE
fix: unbreak install and CI — drop withdrawn tfsm-fire, pin ruff rules and mcp<2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: Install
+      # Two-step so a broken *base* dependency set can't hide behind the extras,
+      # and so an unresolvable extra fails on a line that names the extra.
+      - name: Install (base + dev)
+        run: pip install -e ".[dev]"
+      - name: Install (all extras)
         run: pip install -e ".[dev,all]"
       - name: Lint
         run: ruff check src/ tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to **netlog-ai** are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses
 loose semantic versioning.
 
+## [0.5.1] - 2026-07-28
+
+Packaging hotfix. **`pip install netlog-ai[all]` and `pip install netlog-ai[parse]`
+were failing for every user of the published package**, and CI was red on Python
+3.10 / 3.11 / 3.12.
+
+### Fixed
+
+- **Removed the withdrawn `tfsm-fire` dependency.** Upstream deleted the package from
+  PyPI *and* deleted `github.com/scottpeterman/tfsm_fire`, some time between
+  2026-07-13 (netlog-ai CI installed `tfsm_fire-0.1.0-py3-none-any.whl` cleanly that
+  day) and 2026-07-28 (both 404). There is no surviving fork, mirror, renamed
+  distribution, or Wayback snapshot — the dependency is simply unobtainable, so the
+  extras that required it could not resolve:
+
+  ```text
+  ERROR: Could not find a version that satisfies the requirement tfsm-fire>=0.1.0; extra == "all"
+  ERROR: No matching distribution found for tfsm-fire>=0.1.0; extra == "all"
+  ```
+
+  Repointing the extra at a `git+https://` URL was not an option — the repo is gone,
+  and PyPI rejects PEP 508 direct references in uploaded metadata regardless.
+
+- **Pinned the ruff rule selection**, fixing a *second*, independent CI break that the
+  install failure was masking. `[tool.ruff.lint]` set only `ignore`, never `select`, so
+  the repo inherited ruff's default rule set — while `dev` allows `ruff>=0.5`. ruff
+  0.16.0 broadened those defaults, turning an unmodified `main` from "All checks passed"
+  into **240 findings** with no code change (verified: ruff 0.15.21 passes on
+  `origin/main`, ruff 0.16.0 does not). Lint now explicitly selects `E4, E7, E9, F` —
+  ruff's historical defaults and the set this codebase was written against — so the
+  config no longer drifts with the tool version.
+
+- **Bounded the MCP SDK to `<2`**, fixing a *third* independent break. MCP SDK 2.0
+  removed `mcp.server.fastmcp` (it is now `mcp.server.mcpserver`), which
+  `mcp_server/server.py` imports; `mcp>=1.0` resolved to 2.0.0 and failed
+  `tests/test_mcp_tools.py` on unmodified `main`. Porting to the 2.x API is a real
+  migration and is tracked separately rather than bundled into a packaging hotfix.
+
+All three had the same underlying cause — unpinned dependencies drifting under a repo
+that had not run CI since 2026-07-13 — and each was masked by the one before it.
+
+### Changed
+
+- **`parse` extra removed.** `pip install netlog-ai[parse]` now warns that the extra
+  doesn't exist and installs the base package, instead of hard-failing.
+- **`all` extra reduced to `mcp>=1.0`** — it now installs everything it advertises.
+- **`docs/TFSM_AUTO_PARSER.md`** documents manual installation of `tfsm-fire` plus the
+  template DB for anyone who still has copies, and notes that the templates originate
+  from the still-maintained
+  [networktocode/ntc-templates](https://github.com/networktocode/ntc-templates).
+- CI installs the base `[dev]` set and the full `[dev,all]` set as separate steps, so a
+  broken base dependency can't hide behind the extras.
+
+### Added
+
+- `tests/test_packaging.py` — offline metadata guards: no PEP 508 direct references in
+  any dependency list (they build fine locally but cannot be uploaded to PyPI), no
+  `tfsm-fire` requirement, and `all` stays a superset of the other non-dev extras.
+
+### Unchanged
+
+- `adapters/tfsm_auto.py` and its public API are untouched. It has always been a strict
+  fallback parser that no other feature depends on, and it already degraded to
+  no-match — never raising — when the package or template DB was absent. Set
+  `TFSM_DB_PATH` / `TFSM_DB_URL` and install your own copy of `tfsm-fire` to keep using
+  it; `tests/test_tfsm_auto.py` skips at module level otherwise.
+
 ## [0.5.0] - 2026-07-13
 
 Research-driven wave (competitive study of 2026 NOC tooling — SSE-first live

--- a/README.md
+++ b/README.md
@@ -203,15 +203,16 @@ The topology engine ingests configs from every shipped sample:
 - **Nokia SRL** — `interface ethernet-1/X { subinterface 0 { ipv4 { address ... } } }`, `system0` loopback as implicit VTEP when `afi-safi evpn` is signaled.
 - **FRR** — Quagga-style block syntax, `interface lo` as implicit VTEP when `advertise-all-vni` is present, `vrf X { vni Y }` for L3 VNIs.
 
-### Auto-detection fallback parser (optional)
+### Auto-detection fallback parser (optional, currently unavailable upstream)
 
-For arbitrary `show` output where the platform isn't known up-front, install the `parse`
-extra to enable [tfsm_fire](https://github.com/scottpeterman/tfsm_fire) — it scores every
-TextFSM template in a 700-template DB and returns the best match:
+> **⚠️ Upstream withdrawn (2026-07).** `tfsm-fire` was removed from PyPI and its GitHub
+> repo deleted, with no surviving fork or mirror. The `parse` extra was removed in
+> **v0.5.1** — it made `pip install netlog-ai[parse]` and `[all]` fail for everyone.
+> The adapter below still ships and still works if you supply the package and template
+> DB yourself; it degrades to a no-op otherwise. Nothing else in netlog-ai depends on it.
 
-```bash
-pip install -e ".[parse]"
-```
+For arbitrary `show` output where the platform isn't known up-front, `tfsm_fire` scores
+every TextFSM template in a 700-template DB and returns the best match:
 
 ```python
 from ai_log_analyzer.adapters.tfsm_auto import auto_parse

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -324,7 +324,7 @@ flowchart TB
 |---|---|
 | **Language** | Python 3.10+ (frozen dataclasses, `typing.Protocol`, `re`) |
 | **Web / API** | Flask 3 · flask-cors · gunicorn · vanilla JS · Cytoscape.js + ELK |
-| **Ingest** | `requests` · raw AF_UNIX socket HTTP · `subprocess` (docker CLI) · optional tfsm-fire / TextFSM |
+| **Ingest** | `requests` · raw AF_UNIX socket HTTP · `subprocess` (docker CLI) · optional tfsm-fire / TextFSM (upstream withdrawn 2026-07 — manual install only, see [TFSM_AUTO_PARSER.md](TFSM_AUTO_PARSER.md)) |
 | **Intelligence** | Ollama · Docker Model Runner (OpenAI-compat) · Anthropic Claude (`claude-haiku-4-5`) · rule-based KB |
 | **Security** | `hashlib` (sha256 stable tokens) · `ipaddress` · sanitize-before-LLM gate · X-API-Token · CORS allow-list |
 | **Agent surface** | MCP SDK (FastMCP, optional) over stdio / streamable-http |

--- a/docs/TFSM_AUTO_PARSER.md
+++ b/docs/TFSM_AUTO_PARSER.md
@@ -1,8 +1,28 @@
 # Auto-Detection Parser (tfsm_fire integration)
 
-netlog-ai integrates [scottpeterman/tfsm_fire](https://github.com/scottpeterman/tfsm_fire)
-as an **opt-in fallback parser** for arbitrary CLI output where the platform and command
-aren't known up-front.
+> ## ⚠️ Upstream status: withdrawn (July 2026)
+>
+> `tfsm-fire` has been **removed from PyPI** and `github.com/scottpeterman/tfsm_fire` has
+> been **deleted**. Both return 404. There is no surviving fork, mirror, renamed
+> distribution, or Wayback snapshot, and the template-DB raw URL is dead too.
+>
+> It was installable as recently as **2026-07-13** (netlog-ai CI installed
+> `tfsm_fire-0.1.0-py3-none-any.whl` that day), so pre-existing environments may still
+> have it cached. But it can no longer be obtained from anywhere.
+>
+> **What changed in netlog-ai v0.5.1:** the `parse` extra was removed and `all` reduced
+> to `mcp` only. Keeping the dependency made `pip install netlog-ai[parse]` and
+> `pip install netlog-ai[all]` hard-fail for every user, and broke CI on all Python
+> versions. A `git+https://` direct reference was not an option: the repo is gone, and
+> PyPI rejects direct references in uploaded metadata regardless.
+>
+> **What did not change:** `adapters/tfsm_auto.py` and its API are untouched. The adapter
+> is a strict fallback that nothing else depends on, and it degrades to no-match when the
+> package or DB is absent. If you have a copy of both, everything below still works —
+> see [Installation](#installation).
+
+netlog-ai integrates `tfsm_fire` as an **opt-in fallback parser** for arbitrary CLI output
+where the platform and command aren't known up-front.
 
 ## Why
 
@@ -18,19 +38,35 @@ from ntc-templates) against the input, then returning the one with the highest s
 
 ## Installation
 
-```bash
-pip install -e ".[parse]"   # adds tfsm-fire + textfsm
-```
+There is no longer an extra for this — `pip install netlog-ai[parse]` was removed in
+v0.5.1 because the dependency is unobtainable (see the banner above). Both pieces must
+now be supplied manually.
 
-The template DB (~576 KB SQLite) is **not** bundled in the pip package. It's auto-downloaded
-from the upstream GitHub repo to `~/.cache/netlog-ai/tfsm_templates.db` on first use.
-
-Override the path with the `TFSM_DB_PATH` env var if you want to vendor it elsewhere
-(e.g. for an air-gapped environment):
+**1. The package.** You need a copy of `tfsm-fire` 0.1.0 (imports as `tfire`, depends on
+`textfsm>=1.1.3`). If you have one in an existing environment, an old wheel, or a private
+index:
 
 ```bash
-export TFSM_DB_PATH=/opt/netlog-ai/tfsm_templates.db
+pip install textfsm
+pip install /path/to/tfsm_fire-0.1.0-py3-none-any.whl   # or: pip install -e /path/to/checkout
 ```
+
+**2. The template DB** (~576 KB SQLite). This was never bundled in the pip package — it
+lived only in the upstream GitHub repo, which is gone. The auto-download will fail, so
+point the adapter at your own copy:
+
+```bash
+export TFSM_DB_PATH=/opt/netlog-ai/tfsm_templates.db     # local copy, or
+export TFSM_DB_URL=https://your-mirror.example/tfsm_templates.db
+```
+
+The templates came from [networktocode/ntc-templates](https://github.com/networktocode/ntc-templates),
+which is still actively maintained — a compatible DB can be rebuilt from that source if
+you no longer have the original.
+
+If either piece is missing, `is_available()` returns `False`, `auto_parse()` returns an
+unmatched `ParseResult`, and `tests/test_tfsm_auto.py` skips at module level. Nothing
+raises and no other feature is affected.
 
 ## Quick start
 
@@ -99,7 +135,7 @@ records = parse_output(cmd, filter_hint="bgp_summary")
 
 ### `is_available() -> bool`
 
-Cheap probe — use it to gate UI affordances when the `parse` extra isn't installed.
+Cheap probe — use it to gate UI affordances when `tfsm-fire` isn't installed.
 
 ## Scoring guide
 
@@ -151,7 +187,7 @@ The right mental model: tfsm_fire is the *parser of last resort* when nothing el
 
 ## References
 
-- Upstream repo: https://github.com/scottpeterman/tfsm_fire
-- Template source: https://github.com/networktocode/ntc-templates
+- Upstream repo: `https://github.com/scottpeterman/tfsm_fire` — **deleted, 404 as of 2026-07-28**
+- Template source: https://github.com/networktocode/ntc-templates (still maintained)
 - Our adapter: [`src/ai_log_analyzer/adapters/tfsm_auto.py`](../src/ai_log_analyzer/adapters/tfsm_auto.py)
 - Tests: [`tests/test_tfsm_auto.py`](../tests/test_tfsm_auto.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.5"]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.5",
+    # tests/test_packaging.py reads this file. Python 3.10 has no stdlib tomllib, and
+    # the test skips without a TOML parser — so on 3.10 the guard would silently stop
+    # guarding. pytest currently pulls tomli in transitively there; declare it so the
+    # guard doesn't depend on that continuing to be true.
+    'tomli>=2.0; python_version < "3.11"',
+]
 # Upper bound is deliberate: MCP SDK 2.0 removed `mcp.server.fastmcp` (now
 # `mcp.server.mcpserver`), which mcp_server/server.py imports. `mcp>=1.0` silently
 # resolved to 2.0.0 and broke test_mcp_tools.py on unmodified main. Porting to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netlog-ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "AI-powered network syslog analyzer with pluggable LLM providers (local Docker Model Runner / Anthropic Claude) and lab adapters."
 readme = "README.md"
 license = { text = "MIT" }
@@ -34,12 +34,22 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.5"]
-mcp = ["mcp>=1.0"]
-# Auto-detection parser for arbitrary CLI output (scottpeterman/tfsm_fire).
-# Pulls in textfsm + a SQLite-backed template engine. ~600KB template DB is
-# auto-downloaded to ~/.cache/netlog-ai/ on first use — see docs/TFSM_AUTO_PARSER.md
-parse = ["tfsm-fire>=0.1.0"]
-all = ["mcp>=1.0", "tfsm-fire>=0.1.0"]
+# Upper bound is deliberate: MCP SDK 2.0 removed `mcp.server.fastmcp` (now
+# `mcp.server.mcpserver`), which mcp_server/server.py imports. `mcp>=1.0` silently
+# resolved to 2.0.0 and broke test_mcp_tools.py on unmodified main. Porting to the
+# 2.x API is a real migration, not a CI hotfix — tracked separately. Drop the bound
+# once server.py targets 2.x.
+mcp = ["mcp>=1.0,<2"]
+all = ["mcp>=1.0,<2"]
+# NOTE: there was a `parse = ["tfsm-fire>=0.1.0"]` extra here through v0.5.0.
+# Upstream withdrew `tfsm-fire` from PyPI and deleted github.com/scottpeterman/tfsm_fire
+# between 2026-07-13 (last green CI, which installed tfsm_fire-0.1.0) and 2026-07-28
+# (404 on both). There is no surviving fork, mirror, or renamed distribution, so the
+# extra could not be repointed — it only made `pip install netlog-ai[parse]` and
+# `[all]` unresolvable. The adapter (adapters/tfsm_auto.py) is unchanged and still
+# works if you install a copy of tfsm-fire yourself; see docs/TFSM_AUTO_PARSER.md.
+# Do NOT re-add it as a PEP 508 direct reference (`tfsm-fire @ git+https://...`) —
+# PyPI rejects direct references in uploaded metadata. tests/test_packaging.py enforces this.
 
 [project.urls]
 Homepage = "https://github.com/gesh75/netlog-ai"
@@ -70,5 +80,14 @@ line-length = 110
 target-version = "py310"
 
 [tool.ruff.lint]
+# Pin the rule set explicitly. This was previously omitted, which meant the repo
+# inherited whatever ruff's *default* selection happened to be — and `dev` allows
+# `ruff>=0.5`, so the effective lint config changed under us on every release.
+# ruff 0.16.0 broadened those defaults and turned a clean tree into 240 findings
+# (FURB/I/UP/BLE/RUF/PLW/SIM/...) with no code change. These four are ruff's
+# historical defaults and the set this codebase was actually written against.
+# Adopting the wider set is a worthwhile follow-up, but it's a code change, not a
+# lint-config change — keep it out of a CI hotfix.
+select = ["E4", "E7", "E9", "F"]
 # E701/E702: compact one-line guards (`if x: return y`) are the established style here
 ignore = ["E701", "E702"]

--- a/src/ai_log_analyzer/adapters/tfsm_auto.py
+++ b/src/ai_log_analyzer/adapters/tfsm_auto.py
@@ -13,17 +13,35 @@ tfsm_fire scores every TextFSM template in its SQLite DB against the input and r
 best match. We use it as a strict *fallback* — never the primary path — so regex stays fast
 and tfsm only runs when we don't already have a parser for the input.
 
+Upstream status (as of 2026-07-28) — READ THIS FIRST
+----------------------------------------------------
+`tfsm-fire` has been **withdrawn from PyPI**, and `github.com/scottpeterman/tfsm_fire`
+has been deleted. Both return 404; there is no surviving fork, mirror, or renamed
+distribution. It installed cleanly as recently as 2026-07-13, so older environments may
+still have it — but it can no longer be obtained, and the template-DB URL below is dead
+too. The `parse` extra that used to install it was removed in v0.5.1 because it made
+`pip install netlog-ai[parse]` and `[all]` unresolvable for everyone.
+
+This module is kept intact and fully functional for anyone who still has a copy of the
+package and a copy of the template DB. It is inert (never raises, always returns
+no-match) everywhere else.
+
 Soft-dependency
 ---------------
-`tfsm-fire` is an optional extra (`pip install netlog-ai[parse]`). All public functions return
-an empty/None result if the package isn't installed — they never raise. Use `is_available()`
-to gate UI affordances.
+All public functions return an empty/None result if the package isn't installed — they
+never raise. Use `is_available()` to gate UI affordances.
 
 Template DB
 -----------
-The pip package does NOT ship the 576KB SQLite template DB — it lives only in the upstream
-GitHub repo. We auto-download it once to `~/.cache/netlog-ai/tfsm_templates.db` on first use.
-Override with the `TFSM_DB_PATH` environment variable.
+The pip package never shipped the 576KB SQLite template DB — it lived only in the (now
+deleted) upstream GitHub repo. The auto-download below therefore fails on a stock setup.
+To use this adapter you must supply the DB yourself:
+
+    export TFSM_DB_PATH=/opt/netlog-ai/tfsm_templates.db   # local copy, or
+    export TFSM_DB_URL=https://your-mirror.example/tfsm_templates.db
+
+Templates originate from networktocode/ntc-templates, which is still maintained — a
+compatible DB can be rebuilt from that source.
 """
 from __future__ import annotations
 
@@ -36,9 +54,11 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# Public-facing URL of the upstream template database. Pinned to the main branch.
-# Upstream has restructured before (the raw URL 404s when it does) — override
-# with TFSM_DB_URL to point at a mirror, or TFSM_DB_PATH at a local copy.
+# Historical URL of the upstream template database. The upstream repo was deleted in
+# July 2026, so this default now 404s and _ensure_db() will always fall through to the
+# "download failed" path unless you override it. Retained so environments that already
+# cached the DB keep working, and so it starts working again if upstream is ever
+# restored. Set TFSM_DB_URL to a mirror, or TFSM_DB_PATH to a local copy.
 _UPSTREAM_DB_URL = os.environ.get(
     "TFSM_DB_URL",
     "https://github.com/scottpeterman/tfsm_fire/raw/main/tfire/tfsm_templates.db",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,94 @@
+"""Guards on the published package metadata in pyproject.toml.
+
+Background
+----------
+Through v0.5.0 the `parse` and `all` extras required `tfsm-fire>=0.1.0`. Upstream
+withdrew that package from PyPI and deleted its GitHub repo in July 2026, which made
+`pip install netlog-ai[parse]` and `pip install netlog-ai[all]` hard-fail for every
+user and broke CI on all three supported Python versions.
+
+The obvious-looking repair — repointing the extra at a `git+https://` URL — does not
+work: PyPI rejects PEP 508 direct references in uploaded metadata, so such a wheel
+cannot be published at all. It would pass local `pip install -e .` and then fail at
+release time. These tests exist so that trap is caught in CI instead.
+
+They are pure metadata assertions — no network, no build.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 — pytest pulls tomli in as a transitive dep
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # pragma: no cover - only on a 3.10 env without tomli
+        tomllib = None  # type: ignore[assignment]
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(tomllib is None,
+                       reason="no TOML parser available (Python 3.10 without tomli)"),
+]
+
+
+def _project() -> dict:
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
+def _all_requirements() -> list[tuple[str, str]]:
+    """Every (source, requirement) pair in the published metadata."""
+    project = _project()
+    pairs = [("dependencies", req) for req in project.get("dependencies", [])]
+    for extra, reqs in project.get("optional-dependencies", {}).items():
+        pairs.extend((f"optional-dependencies.{extra}", req) for req in reqs)
+    return pairs
+
+
+def test_no_direct_reference_requirements():
+    """PEP 508 direct references (`name @ url`) cannot be published to PyPI.
+
+    setuptools builds them happily and `pip install -e .` accepts them, so this only
+    surfaces at upload time — after a tag has already been pushed. Catch it here.
+    """
+    offenders = [(src, req) for src, req in _all_requirements() if "@" in req]
+    assert not offenders, (
+        "direct-reference requirements cannot be uploaded to PyPI "
+        f"(twine rejects them): {offenders}"
+    )
+
+
+def test_no_withdrawn_tfsm_fire_dependency():
+    """`tfsm-fire` is gone from PyPI — requiring it makes the package uninstallable.
+
+    See docs/TFSM_AUTO_PARSER.md. The adapter stays; only the hard dependency is gone.
+    """
+    offenders = [
+        (src, req) for src, req in _all_requirements() if "tfsm" in req.lower()
+    ]
+    assert not offenders, (
+        "tfsm-fire was withdrawn from PyPI and its upstream repo deleted; requiring it "
+        f"breaks install for all users: {offenders}"
+    )
+
+
+def test_all_extra_is_superset_of_named_extras():
+    """`all` must actually mean "all the optional features", excluding dev tooling.
+
+    Drift here is how `all` ends up advertising something it no longer installs.
+    """
+    extras = _project().get("optional-dependencies", {})
+    assert "all" in extras, "the `all` extra is documented in the README and must exist"
+
+    aggregate = set(extras["all"])
+    for name, reqs in extras.items():
+        if name in {"all", "dev"}:
+            continue
+        missing = set(reqs) - aggregate
+        assert not missing, f"extra `{name}` has requirements missing from `all`: {missing}"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -16,6 +16,7 @@ They are pure metadata assertions — no network, no build.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -51,6 +52,17 @@ def _all_requirements() -> list[tuple[str, str]]:
     return pairs
 
 
+def _dist_name(requirement: str) -> str:
+    """Normalized (PEP 503) distribution name from a PEP 508 requirement string.
+
+    Matching on the parsed name rather than a substring matters here: `textfsm`
+    *contains* the substring "tfsm", and it is a plausible future dependency —
+    it is the maintained library the withdrawn package was built on.
+    """
+    name = re.split(r"[<>=!~;\[@\s]", requirement.strip(), maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def test_no_direct_reference_requirements():
     """PEP 508 direct references (`name @ url`) cannot be published to PyPI.
 
@@ -64,18 +76,37 @@ def test_no_direct_reference_requirements():
     )
 
 
+WITHDRAWN = {"tfsm-fire"}
+
+
 def test_no_withdrawn_tfsm_fire_dependency():
     """`tfsm-fire` is gone from PyPI — requiring it makes the package uninstallable.
 
     See docs/TFSM_AUTO_PARSER.md. The adapter stays; only the hard dependency is gone.
+
+    Deliberately matches the exact normalized distribution name, not a substring:
+    `textfsm` is a legitimate (and likely) future dependency that contains "tfsm".
     """
     offenders = [
-        (src, req) for src, req in _all_requirements() if "tfsm" in req.lower()
+        (src, req) for src, req in _all_requirements() if _dist_name(req) in WITHDRAWN
     ]
     assert not offenders, (
         "tfsm-fire was withdrawn from PyPI and its upstream repo deleted; requiring it "
         f"breaks install for all users: {offenders}"
     )
+
+
+def test_dist_name_parsing():
+    """_dist_name must key off the parsed name, or the guard above misfires."""
+    assert _dist_name("tfsm-fire>=0.1.0") == "tfsm-fire"
+    assert _dist_name("tfsm_fire >= 0.1.0") == "tfsm-fire"
+    assert _dist_name('tfsm-fire @ git+https://example.invalid/x.git') == "tfsm-fire"
+    assert _dist_name('mcp>=1.0,<2') == "mcp"
+    assert _dist_name('tomli>=2.0; python_version < "3.11"') == "tomli"
+    assert _dist_name("pytest-cov>=5.0") == "pytest-cov"
+    # The false positive this guard exists to avoid:
+    assert _dist_name("textfsm>=1.1.3") == "textfsm"
+    assert _dist_name("textfsm>=1.1.3") not in WITHDRAWN
 
 
 def test_all_extra_is_superset_of_named_extras():

--- a/tests/test_tfsm_auto.py
+++ b/tests/test_tfsm_auto.py
@@ -1,8 +1,10 @@
 """Tests for the tfsm_fire auto-parsing adapter.
 
-These tests are skipped if `tfsm-fire` isn't installed (optional `parse` extra).
-They use real upstream templates against canned device output — no mocking — to
-prove the integration actually works end-to-end against scottpeterman's DB.
+These tests are skipped unless `tfsm-fire` is installed. Since v0.5.1 that means a
+manual install: upstream withdrew the package from PyPI and deleted its GitHub repo
+(see the adapter docstring), so there is no extra that can pull it in. They use real
+templates against canned device output — no mocking — to prove the integration
+actually works end-to-end when the dependency and template DB are present.
 """
 from __future__ import annotations
 
@@ -19,16 +21,16 @@ pytestmark = pytest.mark.unit
 # in environments that haven't installed the `parse` extra.
 # ---------------------------------------------------------------------------
 if not tfsm_auto.is_available():
-    pytest.skip("tfsm-fire not installed (install with: pip install netlog-ai[parse])",
+    pytest.skip("tfsm-fire not installed — withdrawn from PyPI upstream, so there is no "
+                "extra to install it; supply your own copy to run these tests",
                 allow_module_level=True)
 
-# The template DB is a third-party download (upstream GitHub raw file). When
-# upstream is unreachable or has restructured (404), the adapter degrades to
-# no-match by design — skip the end-to-end tests rather than fail CI on an
-# external outage. Point TFSM_DB_URL at a mirror or TFSM_DB_PATH at a local
+# The template DB was a third-party download from the upstream GitHub raw file, which
+# no longer exists. The adapter degrades to no-match by design — skip the end-to-end
+# tests rather than fail CI. Point TFSM_DB_URL at a mirror or TFSM_DB_PATH at a local
 # copy to re-enable them.
 if tfsm_auto._get_engine() is None:
-    pytest.skip("tfsm_fire template DB unavailable (upstream download failed — "
+    pytest.skip("tfsm_fire template DB unavailable (upstream repo deleted — "
                 "set TFSM_DB_URL/TFSM_DB_PATH to a mirror or local copy)",
                 allow_module_level=True)
 

--- a/tests/test_tfsm_auto.py
+++ b/tests/test_tfsm_auto.py
@@ -17,8 +17,9 @@ pytestmark = pytest.mark.unit
 
 
 # ---------------------------------------------------------------------------
-# Skip if the optional extra isn't installed. The unit suite must stay green
-# in environments that haven't installed the `parse` extra.
+# Skip unless tfsm-fire is present. Since v0.5.1 there is no extra that installs
+# it — upstream withdrew the package — so this is a manual-install-only path and
+# these tests skip on every stock checkout. The unit suite must stay green there.
 # ---------------------------------------------------------------------------
 if not tfsm_auto.is_available():
     pytest.skip("tfsm-fire not installed — withdrawn from PyPI upstream, so there is no "


### PR DESCRIPTION
## Summary

`pip install netlog-ai[all]` and `pip install netlog-ai[parse]` fail for **every user of the published package**, and CI is red on Python 3.10 / 3.11 / 3.12.

Investigation turned up **three independent pre-existing breaks**, each masked by the one before it. All three share a root cause: unpinned dependencies drifting while the repo went 15 days without a CI run (last green on `main`: 2026-07-13).

Fixing only the reported one would have left CI red at the next step.

## 1. `tfsm-fire` was withdrawn upstream — *the reported failure*

```
ERROR: Could not find a version that satisfies the requirement tfsm-fire>=0.1.0; extra == "all"
ERROR: No matching distribution found for tfsm-fire>=0.1.0; extra == "all"
```

This is **not** a long-standing typo. It installed cleanly on 2026-07-13 — the CI log for that run shows `tfsm_fire-0.1.0-py3-none-any.whl (26 kB)` downloaded from PyPI. Between then and now, upstream removed it:

| Check | Result |
|---|---|
| `pypi.org/pypi/tfsm-fire/json` | **404** (deleted, not yanked — a yank still returns metadata) |
| `pypi.org/simple/tfsm-fire/` | **404** |
| `github.com/scottpeterman/tfsm_fire` | **404** (author still active, 32 public repos, none matching) |
| GitHub repo search `tfsm_fire` | **0 results** — no forks survived |
| Wayback snapshots (PyPI + GitHub) | **none** |
| Template DB raw URL in `tfsm_auto.py:44` | **404** |
| Renamed/aliased on PyPI? | No — `tfire`, `tfsmfire`, `pytfsm`, `textfsm-fire` all 404; `tfsm` is an unrelated "Trader Finite State Machine" |

**Why not the other options:**

- **(a) git URL** — the repo is gone, and there are no forks or mirrors, so there is nothing to point at. Independently, PyPI rejects PEP 508 direct references in uploaded metadata, so this could never ship in the published wheel.
- **(b) vendor it** — both the 26 KB wheel and the 576 KB template DB are unobtainable, and the license can't be retrieved to verify redistribution rights. Nothing to vendor.
- **(d) correct PyPI name** — none exists (table above).

**→ (c): drop the extra.** `parse` removed; `all` reduced to `mcp`.

`adapters/tfsm_auto.py` is **unchanged** and stays. It has always been a strict fallback that no other feature depends on, and it already degraded to no-match — never raising — when the package or DB was absent. `docs/TFSM_AUTO_PARSER.md` now documents manual installation for anyone who still has copies, and notes the templates came from the still-maintained [ntc-templates](https://github.com/networktocode/ntc-templates).

## 2. ruff 0.16.0 broadened its default rule set

`[tool.ruff.lint]` set only `ignore`, never `select` — so the repo inherited whatever ruff's defaults happened to be, while `dev` allowed `ruff>=0.5`. The effective lint config changed on every ruff release.

Verified against **unmodified `origin/main`**:

| ruff | Result on untouched `main` |
|---|---|
| 0.15.21 (what CI resolved on 2026-07-13) | `All checks passed!` |
| 0.16.0 (what `ruff>=0.5` resolves to today) | **240 errors** |

**→** `select = ["E4", "E7", "E9", "F"]` — ruff's historical defaults, and the set this codebase was actually written against. Adopting the wider set (FURB/I/UP/BLE/…) is worthwhile but it's a **code** change across ~every file, not a lint-config change; keeping it out of a hotfix.

## 3. MCP SDK 2.0 removed `mcp.server.fastmcp`

It is now `mcp.server.mcpserver`. `mcp_server/server.py` imports the old path, so `mcp>=1.0` resolving to `2.0.0` failed `tests/test_mcp_tools.py` on unmodified `main`.

**→** bounded to `mcp>=1.0,<2`. Porting to the 2.x API is a real migration, not a packaging hotfix.

## Changes

- `pyproject.toml` — remove `parse`; `all = ["mcp>=1.0,<2"]`; pin ruff `select`; bump **0.5.0 → 0.5.1**
- `.github/workflows/ci.yml` — install base `[dev]` and full `[dev,all]` as separate steps, so a broken base set can't hide behind extras and failures name the extra
- `tests/test_packaging.py` **(new)** — offline metadata guards: reject PEP 508 direct references (they build fine locally and only fail at *upload*, after a tag is already pushed), reject any `tfsm-fire` requirement, and keep `all` a superset of the other non-dev extras
- `README.md`, `docs/TFSM_AUTO_PARSER.md`, `docs/ARCHITECTURE.md`, adapter docstring, test skip messages — document the upstream withdrawal and manual install
- `CHANGELOG.md` — 0.5.1 entry

## Verification

Clean Python 3.12 venvs (CI matrix version), latest resolvable deps:

| Command | Install | Lint | Tests |
|---|---|---|---|
| `pip install -e '.[dev]'` | ✅ | ✅ clean | ✅ 372 passed, 2 skipped |
| `pip install -e '.[all,dev]'` | ✅ (mcp 1.29.0) | ✅ clean | ✅ 373 passed, 1 skipped |
| `pip install -e '.[parse]'` | ✅ exit 0 + `does not provide the extra 'parse'` warning | — | — |

All three failures were also reproduced on unmodified `origin/main` under Python 3.12 to confirm they are pre-existing and not introduced here.

The 1–2 skips are `test_tfsm_auto.py` (module-level skip — dependency unobtainable, by design) and, in the base venv, `test_mcp_tools.py`.

## Follow-ups (deliberately not in this PR)

Tracked separately so this stays a reviewable hotfix:

1. **#17** — Port `mcp_server/server.py` to MCP SDK 2.x, then drop the `<2` bound.
2. **#18** — Decide on ruff's wider default rule set (240 findings on a clean tree; 207 autofixable, ~20 need judgment).
3. **#19** — Auto-detection parser is dormant for new installs; rebuild the template DB from ntc-templates, swap libraries, or remove the feature.

## Note

Not merging — this needs your review, particularly the scope call on items 2 and 3, which go beyond the originally reported `tfsm-fire` issue but are required for CI to actually go green.
