### PR TITLE
fix(#17): Port MCP server to SDK 2.x (MCPServer)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,10 @@ dev = [
     # guard doesn't depend on that continuing to be true.
     'tomli>=2.0; python_version < "3.11"',
 ]
-# Upper bound is deliberate: MCP SDK 2.0 removed `mcp.server.fastmcp` (now
-# `mcp.server.mcpserver`), which mcp_server/server.py imports. `mcp>=1.0` silently
-# resolved to 2.0.0 and broke test_mcp_tools.py on unmodified main. Porting to the
-# 2.x API is a real migration, not a CI hotfix — tracked separately. Drop the bound
-# once server.py targets 2.x.
-mcp = ["mcp>=1.0,<2"]
-all = ["mcp>=1.0,<2"]
+# MCP SDK 2.x required (FastMCP was renamed to MCPServer and moved to
+# mcp.server.mcpserver). The server was ported in PR #20 / issue #17.
+mcp = ["mcp>=2,<3"]
+all = ["mcp>=2,<3"]
 # NOTE: there was a `parse = ["tfsm-fire>=0.1.0"]` extra here through v0.5.0.
 # Upstream withdrew `tfsm-fire` from PyPI and deleted github.com/scottpeterman/tfsm_fire
 # between 2026-07-13 (last green CI, which installed tfsm_fire-0.1.0) and 2026-07-28

--- a/src/ai_log_analyzer/mcp_server/server.py
+++ b/src/ai_log_analyzer/mcp_server/server.py
@@ -76,7 +76,7 @@ def _build_server():
         raise RuntimeError(
             f"MCP SDK 2.x required (MCPServer at mcp.server.mcpserver); "
             f"found mcp {ver}. Upgrade with `pip install 'mcp>=2,<3'`."
-        ) from exp
+        ) from exc
 
     mcp = MCPServer("netlog-ai")
 

--- a/src/ai_log_analyzer/mcp_server/server.py
+++ b/src/ai_log_analyzer/mcp_server/server.py
@@ -18,7 +18,8 @@ Tools exposed:
   - analyze_site          : run full site-wide analysis on a bundle
 
 The MCP SDK is an optional dependency — install with
-`pip install netlog-ai[mcp]` or `pip install mcp`.
+`pip install netlog-ai[mcp]` or `pip install 'mcp>=2,<3'`.
+Requires MCP SDK 2.x (MCPServer). See issue #17.
 """
 from __future__ import annotations
 
@@ -53,17 +54,31 @@ _SITES_DIR = _resolve_sites_dir()
 
 
 def _build_server():
-    """Construct the FastMCP server. Deferred import so the rest of the
-    package works even when the MCP SDK isn't installed."""
-    try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError as exc:  # noqa: BLE001
-        raise RuntimeError(
-            "MCP SDK not installed. Run `pip install mcp` "
-            "or `pip install netlog-ai[mcp]`."
-        ) from exc
+    """Construct the MCPServer (MCP SDK 2.x). Deferred import so the rest of the
+    package works even when the MCP SDK isn't installed.
 
-    mcp = FastMCP("netlog-ai")
+    MCP SDK 2.0 renamed FastMCP → MCPServer and moved the import path to
+    `mcp.server.mcpserver`. The decorator surface (`@mcp.tool()`) is unchanged.
+    """
+    try:
+        from mcp.server.mcpserver import MCPServer
+    except ImportError as exc:
+        # Distinguish "SDK absent" from "SDK present but wrong major" so the next
+        # break reports itself accurately (issue #17).
+        try:
+            import mcp as _mcp
+        except ImportError:
+            raise RuntimeError(
+                "MCP SDK not installed. Run `pip install 'mcp>=2,<3'` "
+                "or `pip install netlog-ai[mcp]`."
+            ) from exc
+        ver = getattr(_mcp, "__version__", "unknown")
+        raise RuntimeError(
+            f"MCP SDK 2.x required (MCPServer at mcp.server.mcpserver); "
+            f"found mcp {ver}. Upgrade with `pip install 'mcp>=2,<3'`."
+        ) from exp
+
+    mcp = MCPServer("netlog-ai")
 
     # ── inventory ────────────────────────────────────────────────────────────
     @mcp.tool()
@@ -334,7 +349,6 @@ def run(transport: str = "stdio") -> None:
     Auto-loads env-configured sources before serving so the MCP client sees
     them immediately on list_sources().
     """
-    # Eager-load env sources so tools like list_sources() work out of the box
     try:
         source_manager.load_from_env()
     except Exception:  # noqa: BLE001
@@ -343,8 +357,6 @@ def run(transport: str = "stdio") -> None:
     server = _build_server()
     if transport not in {"stdio", "streamable-http"}:
         raise ValueError(f"Unsupported transport: {transport!r}")
-    # FastMCP.run() accepts no kwargs in stdio mode; pass transport in
-    # streamable-http mode.
     if transport == "stdio":
         server.run()
     else:


### PR DESCRIPTION
## Summary
Ports `mcp_server/server.py` from FastMCP (SDK 1.x) to `MCPServer` (SDK 2.x) and drops the `mcp<2` pin.

## Changes
- Import `MCPServer` from `mcp.server.mcpserver`
- Error path distinguishes missing SDK vs wrong major version
- Typo fix on exception chaining

## Follow-ups (not in this PR)
- #18 ruff wider rules (incremental)
- #19 tfsm-fire rebuild vs remove decision

## Test plan
- [ ] `pip install -e ".[mcp,dev]"` resolves mcp 2.x
- [ ] `pytest tests/test_mcp_tools.py -q` green
- [ ] Full suite green on 3.10/3.11/3.12