### PR TITLE
fix: restrict containerlab docker exec targets

### DIFF
--- a/src/ai_log_analyzer/adapters/frr.py
+++ b/src/ai_log_analyzer/adapters/frr.py
@@ -108,10 +108,16 @@ def frr_docker_logs(
 def list_lab_containers(
     prefix_filter: tuple[str, ...] = (
         "de-", "uk-", "nl-", "us-",  # original FRR site-coded lab
-        "clab-",                     # containerlab multi-vendor fabric (clab-clos-evpn-*, etc.)
+    ),
+    name_filter: tuple[str, ...] = (
+        # Nodes in the bundled containerlab multi-vendor fabric.  Do not use
+        # the generic ``clab-`` prefix here: /api/run treats this inventory as
+        # the authorization boundary for its docker-exec fallback.
+        *(f"clab-clos-evpn-leaf{i}" for i in range(1, 7)),
+        *(f"clab-clos-evpn-spine{i}" for i in range(1, 4)),
     ),
 ) -> list[str]:
-    """Return running containers matching lab naming prefixes."""
+    """Return running containers belonging to the bundled labs."""
     if not shutil.which("docker"):
         return []
     try:
@@ -122,4 +128,4 @@ def list_lab_containers(
     except subprocess.CalledProcessError:
         return []
     names = [n.strip() for n in proc.stdout.splitlines() if n.strip()]
-    return sorted(n for n in names if n.startswith(prefix_filter))
+    return sorted(n for n in names if n.startswith(prefix_filter) or n in name_filter)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,8 +1,28 @@
 """Tests for log adapters (FRR + generic file)."""
+from unittest.mock import Mock
+
 import pytest
 
+from ai_log_analyzer.adapters import frr
 from ai_log_analyzer.adapters.file import parse_lines
 from ai_log_analyzer.adapters.frr import parse_frr_line
+
+
+@pytest.mark.unit
+def test_lab_container_inventory_excludes_unrelated_containerlab_nodes(monkeypatch):
+    """Only the bundled clab fabric may cross the docker-exec trust boundary."""
+    monkeypatch.setattr(frr.shutil, "which", lambda _binary: "/usr/bin/docker")
+    monkeypatch.setattr(
+        frr.subprocess,
+        "run",
+        Mock(return_value=Mock(stdout="\n".join((
+            "clab-clos-evpn-leaf1",
+            "clab-unrelated-linux",
+            "de-fra-core-01",
+        )))),
+    )
+
+    assert frr.list_lab_containers() == ["clab-clos-evpn-leaf1", "de-fra-core-01"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Motivation

- The docker-exec fallback used membership in `frr.list_lab_containers()` as an authorization boundary, and adding the generic `clab-` prefix expanded that trust to any containerlab container which could allow reading secrets or running disruptive `ip` commands inside unrelated containers.

### Description

- Replace the broad `clab-` discovery rule with an explicit allowlist of the nine bundled `clab-clos-evpn-*` nodes and preserve the original FRR site-coded prefixes in `list_lab_containers()` in `src/ai_log_analyzer/adapters/frr.py`.
- Adjust the filter logic so inventory only includes names that match the site prefixes or are in the explicit bundled-node allowlist (`name_filter`).
- Add a regression test `test_lab_container_inventory_excludes_unrelated_containerlab_nodes` in `tests/test_adapters.py` that verifies a bundled `clab-clos-evpn-*` node is included while an unrelated `clab-*` Linux container is excluded.

### Testing

- Ran `git diff --check` and `ruff check` on the modified files and they reported no issues.
- Ran `PYTHONPATH=src pytest -q tests/test_adapters.py tests/test_web_security.py` and the targeted tests passed successfully.
- Ran the full suite with `PYTHONPATH=src pytest -q` and the test run completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7506d6eee8832f84c99fbffbed36d2)