### PR TITLE
fix(file): confine and bound directory log scans

### DIFF
--- a/src/ai_log_analyzer/adapters/file.py
+++ b/src/ai_log_analyzer/adapters/file.py
@@ -1,7 +1,10 @@
 """Generic syslog/file adapter — parse RFC3164 / RFC5424 / freeform log files."""
 from __future__ import annotations
 
+import fnmatch
+import os
 import re
+from itertools import islice
 from pathlib import Path
 from typing import Iterable
 
@@ -48,6 +51,44 @@ _SCRT_RE = re.compile(
 # Filename pattern SecureCRT uses: "<hostname> (<ip>) -- YYYY-MM-DD_HH-MM"
 _SCRT_FILENAME_RE = re.compile(r"^(?P<host>[A-Za-z0-9][\w.\-]*)\s*\(")
 
+_MAX_DIRECTORY_FILES = 500
+_MAX_DIRECTORY_ENTRIES = 10_000
+
+
+def _validated_file_pattern(pattern: str) -> str:
+    """Accept a filename glob, but never a path that can escape the scan root."""
+    if not isinstance(pattern, str) or not pattern or pattern in {".", ".."}:
+        raise ValueError("directory pattern must be a non-empty filename glob")
+    if "/" in pattern or "\\" in pattern or ".." in pattern:
+        raise ValueError("directory pattern must not contain path components")
+    return pattern
+
+
+def _matching_files(path: Path, pattern: str, recursive: bool) -> Iterable[Path]:
+    pattern = _validated_file_pattern(pattern)
+    root = path.resolve()
+    pending = [root]
+    scanned = 0
+    while pending and scanned < _MAX_DIRECTORY_ENTRIES:
+        directory = pending.pop()
+        try:
+            entries = os.scandir(directory)
+        except OSError:
+            continue
+        with entries:
+            for entry in entries:
+                scanned += 1
+                if scanned > _MAX_DIRECTORY_ENTRIES:
+                    return
+                try:
+                    if recursive and entry.is_dir(follow_symlinks=False):
+                        pending.append(Path(entry.path))
+                    elif (entry.is_file(follow_symlinks=False)
+                          and fnmatch.fnmatchcase(entry.name, pattern)):
+                        yield Path(entry.path)
+                except OSError:
+                    continue
+
 
 def parse_lines(lines: Iterable[str], default_host: str = "") -> Iterable[LogEvent]:
     """Parse any iterable of log lines, picking the first format that matches."""
@@ -73,7 +114,8 @@ def parse_file(path: str | Path, default_host: str = "") -> Iterable[LogEvent]:
 
 
 def parse_directory(path: str | Path, pattern: str = "*.log",
-                    recursive: bool = True, max_files: int = 500) -> Iterable[LogEvent]:
+                    recursive: bool = True,
+                    max_files: int = _MAX_DIRECTORY_FILES) -> Iterable[LogEvent]:
     """Parse every file in a directory matching `pattern` and yield all events
     in chronological-ish order (by filename sort, then by file order).
 
@@ -82,30 +124,28 @@ def parse_directory(path: str | Path, pattern: str = "*.log",
     sessions on the same device naturally group together).
 
     `max_files` is a safety cap to prevent accidental analysis of a 100K-file
-    directory. Set to 0 to disable.
+    directory. It cannot be disabled: non-positive values use the default cap.
     """
     p = Path(path)
     if not p.is_dir():
         raise ValueError(f"{p} is not a directory")
-    if recursive:
-        files = sorted(f for f in p.rglob(pattern) if f.is_file())
-    else:
-        files = sorted(f for f in p.glob(pattern) if f.is_file())
-    if max_files and len(files) > max_files:
-        files = files[:max_files]
+    limit = max_files if max_files > 0 else _MAX_DIRECTORY_FILES
+    # Apply the cap while iterating. Do not materialize and sort an attacker-
+    # controlled number of matches before truncating the result.
+    files = sorted(islice(_matching_files(p, pattern, recursive), limit))
     for f in files:
         yield from parse_file(f)
 
 
 def count_directory_files(path: str | Path, pattern: str = "*.log",
-                          recursive: bool = True) -> int:
-    """Cheap precheck — how many matching files would parse_directory ingest?"""
+                          recursive: bool = True,
+                          max_files: int = _MAX_DIRECTORY_FILES) -> int:
+    """Return a bounded count of files that ``parse_directory`` can ingest."""
     p = Path(path)
     if not p.is_dir():
         return 0
-    if recursive:
-        return sum(1 for f in p.rglob(pattern) if f.is_file())
-    return sum(1 for f in p.glob(pattern) if f.is_file())
+    limit = max_files if max_files > 0 else _MAX_DIRECTORY_FILES
+    return sum(1 for _ in islice(_matching_files(p, pattern, recursive), limit))
 
 
 def _parse_line(line: str, default_host: str) -> LogEvent | None:

--- a/src/ai_log_analyzer/web/app.py
+++ b/src/ai_log_analyzer/web/app.py
@@ -682,8 +682,11 @@ def create_app() -> Flask:
                 # via body.pattern). Cap at 500 files for safety.
                 pattern = body.get("pattern", "*.log")
                 recursive = _parse_bool(body.get("recursive", True), default=True)
-                file_count = count_directory_files(p, pattern=pattern,
-                                                    recursive=recursive)
+                try:
+                    file_count = count_directory_files(p, pattern=pattern,
+                                                       recursive=recursive)
+                except ValueError as exc:
+                    return jsonify({"error": str(exc)}), 400
                 if file_count == 0:
                     return jsonify({
                         "error": f"No files matching {pattern!r} in {path}",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -252,3 +252,47 @@ def test_count_directory_files_matches_glob(tmp_path):
     assert count_directory_files(tmp_path, pattern="*.log", recursive=False) == 2
     assert count_directory_files(tmp_path, pattern="*.log", recursive=True) == 3
     assert count_directory_files(tmp_path / "does-not-exist") == 0
+
+
+@pytest.mark.unit
+def test_directory_scan_rejects_path_patterns(tmp_path):
+    from ai_log_analyzer.adapters.file import count_directory_files, parse_directory
+
+    outside = tmp_path / "secret.log"
+    outside.write_text("TOP SECRET\n", encoding="utf-8")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+
+    with pytest.raises(ValueError, match="path components"):
+        count_directory_files(allowed, pattern="../secret.log", recursive=False)
+    with pytest.raises(ValueError, match="path components"):
+        list(parse_directory(allowed, pattern="**/*.log"))
+
+
+@pytest.mark.unit
+def test_directory_scan_caps_before_materializing_matches(tmp_path, monkeypatch):
+    from ai_log_analyzer.adapters import file as file_adapter
+
+    visited = []
+
+    def matches(_path, _pattern, _recursive):
+        for index in range(1000):
+            visited.append(index)
+            yield tmp_path / f"{index:04}.log"
+
+    monkeypatch.setattr(file_adapter, "_matching_files", matches)
+    assert file_adapter.count_directory_files(tmp_path, max_files=3) == 3
+    assert len(visited) == 3
+
+
+@pytest.mark.unit
+def test_directory_scan_does_not_follow_file_symlinks(tmp_path):
+    from ai_log_analyzer.adapters.file import count_directory_files
+
+    outside = tmp_path / "secret.log"
+    outside.write_text("TOP SECRET\n", encoding="utf-8")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    (allowed / "linked.log").symlink_to(outside)
+
+    assert count_directory_files(allowed) == 0

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -98,6 +98,24 @@ def test_file_source_traversal_is_blocked(client, monkeypatch, tmp_path):
     assert r.status_code == 403
 
 
+@pytest.mark.unit
+def test_directory_source_pattern_cannot_escape_root(client, monkeypatch, tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    (tmp_path / "secret.log").write_text("TOP SECRET\n", encoding="utf-8")
+    monkeypatch.setattr(web_app, "FILE_ROOTS", [tmp_path])
+
+    r = client.post("/api/analyze", json={
+        "source": "file",
+        "path": str(allowed),
+        "pattern": "../secret.log",
+        "recursive": False,
+        "use_llm": False,
+    })
+    assert r.status_code == 400
+    assert "path components" in r.get_json()["error"]
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # /api/llm/status redaction
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Directory-mode file ingestion accepted caller-controlled glob patterns and performed uncapped rglob/glob traversals and sorting, which allowed path-traversal (`..`), symlink escape, and large filesystem walks that can expose server-readable files and cause resource exhaustion. 
- Harden scanning to validate patterns, prevent escaping the requested root, and cap both traversal work and matched-file processing to mitigate information disclosure and DoS risk.

### Description

- Add filename-pattern validation and an iterative, bounded directory walker in `src/ai_log_analyzer/adapters/file.py` that rejects path components (`/`, `\`, `..`), avoids following symlinks, and enforces a maximum entries scanned and files matched (`_MAX_DIRECTORY_ENTRIES`, `_MAX_DIRECTORY_FILES`).
- Change `parse_directory` to apply the file cap during iteration (using `_matching_files` + `islice`) so matches are not fully materialized and sorted before truncation, and make `count_directory_files` return a bounded count.
- Update `/api/analyze` in `src/ai_log_analyzer/web/app.py` to catch invalid directory-pattern `ValueError` and return HTTP 400 instead of performing the scan.
- Add regression tests that cover rejecting unsafe patterns, ensuring the cap is applied before materializing matches, preventing symlink-following escapes, and exercising the endpoint-level pattern rejection in `tests/test_adapters.py` and `tests/test_web_security.py`.

### Testing

- Ran `git diff --check` and it reported no issues. 
- Ran the targeted unit tests: `PYTHONPATH=src pytest -q tests/test_adapters.py tests/test_web_security.py` and they passed. 
- Ran linter checks: `ruff check src/ai_log_analyzer/adapters/file.py src/ai_log_analyzer/web/app.py tests/test_adapters.py tests/test_web_security.py` and they passed. 
- Ran the full test suite: `PYTHONPATH=src pytest -q` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7506f53040832f819a493f554331f0)