### PR TITLE
Sanitize saved playbooks before LLM judge evaluation

### DIFF
--- a/src/ai_log_analyzer/judge.py
+++ b/src/ai_log_analyzer/judge.py
@@ -29,6 +29,7 @@ import re
 from typing import Any
 
 from ai_log_analyzer import llm
+from ai_log_analyzer.sanitize import sanitize
 
 # Same placeholder pattern the analyzer scrubs — a playbook naming R1/SW2
 # instead of real inventory is hallucinating.
@@ -160,8 +161,12 @@ def judge_playbook_llm(deep: dict, devices: list[str] | None = None) -> dict[str
     """LLM pass — returns None when no provider is reachable or output is junk."""
     if not llm.is_enabled():
         return None
-    prompt = (f"AFFECTED DEVICES: {devices or ['unknown']}\n\n"
-              f"PLAYBOOK JSON:\n{json.dumps(deep, indent=1)[:6000]}\n\nScore it now.")
+    # Saved analysis results retain raw log samples for the local UI. Treat
+    # every field as untrusted before sending the playbook to a provider.
+    safe_devices, _ = sanitize(json.dumps(devices or ["unknown"]), mask_pii=True)
+    safe_deep, _ = sanitize(json.dumps(deep, indent=1), mask_pii=True)
+    prompt = (f"AFFECTED DEVICES: {safe_devices}\n\n"
+              f"PLAYBOOK JSON:\n{safe_deep[:6000]}\n\nScore it now.")
     text = llm.query(_LLM_JUDGE_PROMPT, prompt, max_tokens=200)
     if not text:
         return None

--- a/tests/test_stability_judge.py
+++ b/tests/test_stability_judge.py
@@ -161,6 +161,33 @@ def test_judge_llm_blend_merges_scores(monkeypatch):
     assert v["scores"]["overall"] > heuristic_only["scores"]["overall"]
 
 
+def test_judge_llm_sanitizes_saved_log_samples(monkeypatch):
+    from ai_log_analyzer import llm
+    captured = {}
+
+    monkeypatch.setattr(llm, "is_enabled", lambda: True)
+
+    def capture_query(_system, prompt, **_kwargs):
+        captured["prompt"] = prompt
+        return json.dumps({
+            "actionability": 10, "safety": 10,
+            "grounding": 10, "completeness": 10,
+        })
+
+    monkeypatch.setattr(llm, "query", capture_query)
+    playbook = dict(GOOD_PLAYBOOK)
+    playbook["sample_messages"] = [
+        "neighbor 8.8.8.8 password 7 ULTRA_SECRET_CANARY username admin",
+    ]
+
+    assert judge.judge_playbook_llm(playbook) is not None
+    prompt = captured["prompt"]
+    assert "ULTRA_SECRET_CANARY" not in prompt
+    assert "8.8.8.8" not in prompt
+    assert "username admin" not in prompt
+    assert "<REDACTED>" in prompt
+
+
 # ── eval CLI ─────────────────────────────────────────────────────────────────
 
 def test_cli_eval_kb_self_test(capsys):


### PR DESCRIPTION
### Motivation

- The LLM judge path previously serialized saved `deep_analysis` objects (including raw `sample_messages`) and sent them verbatim to the configured LLM provider, risking exfiltration of secrets and PII. 

### Description

- Import and use the existing `sanitize()` function to redact secrets and mask PII when constructing the LLM prompt for the judge, applying it to both the affected-device context and the serialized playbook before the `llm.query()` call in `judge_playbook_llm`. 
- Preserve the original prompt-size guard by truncating the sanitized JSON to the same limit. 
- Add a regression test `test_judge_llm_sanitizes_saved_log_samples` that monkeypatches the provider call, captures the produced prompt, and asserts that a password token, public IP, and username from saved samples are not present while redaction markers are. 

### Testing

- Ran `PYTHONPATH=src pytest -q tests/test_stability_judge.py` and the targeted tests passed. 
- Ran the full suite with `PYTHONPATH=src pytest -q` and it completed successfully. 
- Ran `PYTHONPATH=src python -m ruff check src/ai_log_analyzer/judge.py tests/test_stability_judge.py` and static checks passed. 
- Ran `git diff --check` to verify no whitespace/trailing issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89c3a40832fa6ba992d7ad4e9fa)