### PR TITLE
Require API token for /api/incidents/similar (protect incident journal search)

### DIFF
--- a/src/ai_log_analyzer/web/app.py
+++ b/src/ai_log_analyzer/web/app.py
@@ -830,6 +830,7 @@ def create_app() -> Flask:
 
     # ── Incident memory ────────────────────────────────────────────────────
     @app.route("/api/incidents/similar", methods=["GET"])
+    @require_api_token
     def api_incidents_similar():
         """Free-text search over the local incident journal.
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -65,6 +65,16 @@ def test_sources_test_and_fetch_require_token(client, monkeypatch):
     assert client.post("/api/rules", json={}).status_code == 401
 
 
+@pytest.mark.unit
+def test_incident_search_requires_token(client, monkeypatch):
+    """Incident history must not be searchable anonymously when tokened."""
+    monkeypatch.setattr(web_app, "API_TOKEN", "sekrit")
+    url = "/api/incidents/similar?q=router"
+    assert client.get(url).status_code == 401
+    assert client.get(url, headers={"X-API-Token": "wrong"}).status_code == 401
+    assert client.get(url, headers={"X-API-Token": "sekrit"}).status_code != 401
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # /api/analyze {source:"file"} path confinement
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- The `/api/incidents/similar` endpoint exposed metadata from the opt-in incident journal without enforcing `AI_LOG_ANALYZER_API_TOKEN`, allowing unauthenticated callers to probe stored incident history.
- The change is intended to close this information-disclosure gap by applying the same API-token guard used elsewhere in the app.

### Description

- Add the existing authorization decorator to the incident search endpoint by adding `@require_api_token` to `api_incidents_similar` in `src/ai_log_analyzer/web/app.py`.
- Add a regression test `test_incident_search_requires_token` to `tests/test_web_security.py` that asserts anonymous and wrong tokens receive `401` while the correct token is accepted.
- Keep development behaviour unchanged when `AI_LOG_ANALYZER_API_TOKEN` is unset because `require_api_token` is a no-op in that mode.

### Testing

- Ran `PYTHONPATH=src pytest -q tests/test_web_security.py tests/test_incident_memory.py` which passed for the modified tests and relevant coverage.
- Ran static checks with `PYTHONPATH=src ruff check src/ai_log_analyzer/web/app.py tests/test_web_security.py` which reported no issues.
- Ran the full test suite with `PYTHONPATH=src pytest` which completed successfully with `374 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c7338ad4832fb167c5e531fa55e1)