### PR TITLE
Fix: bound custom regex evaluation to prevent ReDoS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "requests>=2.32",
     "python-dotenv>=1.0",
     "gunicorn>=23.0",
+    "regex>=2024.7.24",
 ]
 
 [project.optional-dependencies]

--- a/src/ai_log_analyzer/classifier.py
+++ b/src/ai_log_analyzer/classifier.py
@@ -10,6 +10,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Iterable, Iterator
 
+import regex
+
 # (regex, severity, category, description) — first match wins.
 # Patterns tested against f"{appname} {message}".lower()
 _KB_PATTERNS: list[tuple[str, str, str, str]] = [
@@ -191,7 +193,10 @@ _KEYWORDS = tuple(sorted(
 # Custom rules are checked BEFORE the built-in KB so operators can override
 # any built-in verdict. They bypass the literal gate — rule counts are small,
 # so the extra scans are negligible.
-_CUSTOM_RULES: list[tuple[re.Pattern[str], str, str, str]] = []
+_MAX_CUSTOM_RULES = 100
+_MAX_CUSTOM_PATTERN_LENGTH = 512
+_CUSTOM_REGEX_TIMEOUT_SECONDS = 0.01
+_CUSTOM_RULES: list[tuple[regex.Pattern, str, str, str]] = []
 
 
 def add_custom_rules(rules: list[dict]) -> tuple[int, list[str]]:
@@ -203,6 +208,9 @@ def add_custom_rules(rules: list[dict]) -> tuple[int, list[str]]:
     """
     added, errors = 0, []
     for i, rule in enumerate(rules):
+        if len(_CUSTOM_RULES) >= _MAX_CUSTOM_RULES:
+            errors.append(f"rule {i}: custom rule limit ({_MAX_CUSTOM_RULES}) reached")
+            continue
         if not isinstance(rule, dict):
             errors.append(f"rule {i}: not an object")
             continue
@@ -213,9 +221,17 @@ def add_custom_rules(rules: list[dict]) -> tuple[int, list[str]]:
         if severity not in SEV_ORDER:
             errors.append(f"rule {i}: invalid severity {severity!r}")
             continue
+        if not isinstance(pattern, str) or not pattern:
+            errors.append(f"rule {i}: pattern must be a non-empty string")
+            continue
+        if len(pattern) > _MAX_CUSTOM_PATTERN_LENGTH:
+            errors.append(
+                f"rule {i}: pattern exceeds {_MAX_CUSTOM_PATTERN_LENGTH} characters"
+            )
+            continue
         try:
-            compiled = re.compile(pattern, re.IGNORECASE)
-        except re.error as exc:
+            compiled = regex.compile(pattern, regex.IGNORECASE)
+        except regex.error as exc:
             errors.append(f"rule {i}: bad regex: {exc}")
             continue
         _CUSTOM_RULES.append((compiled, severity, category, description))
@@ -355,7 +371,15 @@ def iter_classify(events: Iterable[LogEvent]) -> Iterator[ClassifiedEvent]:
 
         # Custom user rules take precedence over the built-in KB.
         for pattern, p_sev, p_cat, p_desc in _CUSTOM_RULES:
-            if pattern.search(combined):
+            try:
+                matched = pattern.search(
+                    combined, timeout=_CUSTOM_REGEX_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                # Treat pathological rules as non-matches rather than letting
+                # attacker-controlled log text monopolize a worker.
+                matched = None
+            if matched:
                 sev, cat, desc = p_sev, p_cat, p_desc
                 confidence = 1.0
                 break
@@ -419,4 +443,3 @@ def classify_events(events: Iterable[LogEvent]) -> tuple[list[ClassifiedEvent], 
     classified.sort(key=lambda e: e.timestamp, reverse=True)
     classified.sort(key=lambda e: SEV_ORDER.get(e.severity, 5))
     return classified, sev_counts, cat_counts
-

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import time
 
 import pytest
 
@@ -62,6 +63,37 @@ def test_invalid_rules_are_skipped_with_errors():
     ])
     assert added == 1
     assert len(errors) == 3
+
+
+def test_custom_rule_catastrophic_backtracking_is_bounded():
+    added, errors = classifier.add_custom_rules([{
+        "pattern": r"(a+)+$", "severity": "high",
+    }])
+    assert added == 1 and not errors
+
+    started = time.monotonic()
+    events, _, _ = classify_events([_event("a" * 10_000 + "!")])
+    assert time.monotonic() - started < 1
+    assert events[0].severity == "info"
+
+
+def test_custom_rule_count_and_pattern_length_are_limited():
+    rules = [{"pattern": f"rule-{i}", "severity": "low"}
+             for i in range(classifier._MAX_CUSTOM_RULES + 1)]
+    added, errors = classifier.add_custom_rules(rules)
+    assert added == classifier._MAX_CUSTOM_RULES
+    assert errors == [
+        f"rule {classifier._MAX_CUSTOM_RULES}: custom rule limit "
+        f"({classifier._MAX_CUSTOM_RULES}) reached"
+    ]
+
+    classifier._CUSTOM_RULES.clear()
+    added, errors = classifier.add_custom_rules([{
+        "pattern": "x" * (classifier._MAX_CUSTOM_PATTERN_LENGTH + 1),
+        "severity": "low",
+    }])
+    assert added == 0
+    assert "exceeds" in errors[0]
 
 
 def test_load_custom_rules_file(tmp_path):


### PR DESCRIPTION
### Motivation

- Prevent a ReDoS/CPU exhaustion attack where user-supplied custom regexes (via the runtime rules API) can catastrophically backtrack when evaluated against attacker-controlled log text. 
- Reduce risk from unbounded operator mistakes by limiting the number and size of custom rules so a process cannot be degraded over time. 

### Description

- Add the `regex` engine and use `regex.compile`/`pattern.search(..., timeout=...)` to enforce a per-evaluation timeout via `_CUSTOM_REGEX_TIMEOUT_SECONDS` and treat timeouts as non-matches. 
- Enforce resource limits with `_MAX_CUSTOM_RULES = 100` and `_MAX_CUSTOM_PATTERN_LENGTH = 512`, and validate that `pattern` is a non-empty string before compiling. 
- Add `regex>=2024.7.24` to `pyproject.toml` and extend `tests/test_custom_rules.py` with regression tests for catastrophic backtracking, rule-count exhaustion, and oversized patterns. 

### Testing

- Ran `python -m compileall -q src tests` which succeeded. 
- Ran linting with `ruff check .` which succeeded and `git diff --check` which passed. 
- Attempted `PYTHONPATH=src pytest -q tests/test_custom_rules.py` but execution was blocked because the environment did not have the new `regex` dependency installed. 
- Attempted `python -m pip install -e .` to install deps but the run failed due to restricted package-index/network access in the environment, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89b821c832fa21a056f4ed85478)