### PR TITLE
fix: sanitize outbound webhook payloads

### DIFF
--- a/src/ai_log_analyzer/webhooks.py
+++ b/src/ai_log_analyzer/webhooks.py
@@ -21,11 +21,23 @@ from typing import Any
 
 import requests
 
+from ai_log_analyzer.sanitize import sanitize
+
 logger = logging.getLogger(__name__)
 
 _SEV_RANK: dict[str, int] = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
 _TIMEOUT_S = 5
 _MAX_ACTION_ITEMS = 5
+
+
+def _sanitize_text(value: Any) -> str:
+    """Remove secrets and PII from an analysis-derived payload field."""
+    return sanitize(str(value), mask_pii=True)[0]
+
+
+def _slack_text(value: Any) -> str:
+    """Sanitize user-controlled text and disable Slack link/mention parsing."""
+    return _sanitize_text(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
 def _config() -> tuple[str, str, str]:
@@ -63,11 +75,11 @@ def build_payload(result: dict[str, Any], source: str, fmt: str, min_severity: s
     summary + top action items — payloads stay small and post-sanitize."""
     top_actions = [
         {
-            "severity": a.get("severity", ""),
-            "category": a.get("category", ""),
-            "description": a.get("description", ""),
+            "severity": _sanitize_text(a.get("severity", "")),
+            "category": _sanitize_text(a.get("category", "")),
+            "description": _sanitize_text(a.get("description", "")),
             "count": a.get("count", 0),
-            "devices": a.get("devices", [])[:5],
+            "devices": [_sanitize_text(device) for device in a.get("devices", [])[:5]],
         }
         for a in result.get("action_items", [])[:_MAX_ACTION_ITEMS]
     ]
@@ -75,19 +87,19 @@ def build_payload(result: dict[str, Any], source: str, fmt: str, min_severity: s
         alerting = _alerting_counts(result, min_severity)
         sev_line = ", ".join(f"{n} {sev}" for sev, n in alerting.items()) or "events"
         lines = [
-            f":rotating_light: *netlog-ai* — {sev_line} from *{source}* "
+            f":rotating_light: *netlog-ai* — {sev_line} from *{_slack_text(source)}* "
             f"(health {result.get('score', '?')}/100, grade {result.get('grade', '?')})"
         ]
         lines += [
-            f"• [{a['severity'].upper()}] {a['description']} "
-            f"(×{a['count']} on {', '.join(a['devices']) or 'n/a'})"
+            f"• [{_slack_text(a['severity']).upper()}] {_slack_text(a['description'])} "
+            f"(×{a['count']} on {', '.join(_slack_text(d) for d in a['devices']) or 'n/a'})"
             for a in top_actions
         ]
         return {"text": "\n".join(lines)}
     return {
         "source": "netlog-ai",
         "event": "analysis_completed",
-        "input": source,
+        "input": _sanitize_text(source),
         "score": result.get("score"),
         "grade": result.get("grade"),
         "severity_counts": result.get("severity_counts", {}),

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -67,6 +67,31 @@ def test_slack_payload_shape():
     assert "medium" not in p["text"].split("\n")[0]  # below threshold not in headline
 
 
+@pytest.mark.unit
+def test_payloads_redact_raw_log_secrets_and_slack_mentions():
+    result = {
+        **RESULT,
+        "action_items": [{
+            "severity": "high",
+            "category": "system",
+            "description": "snmp-server community TopSecretRO ro <!channel>",
+            "count": 1,
+            "devices": ["8.8.8.8"],
+        }],
+    }
+
+    generic = webhooks.build_payload(result, "snmp-server community SourceSecret ro",
+                                     "generic", "high")
+    assert "TopSecretRO" not in generic["action_items"][0]["description"]
+    assert "SourceSecret" not in generic["input"]
+    assert generic["action_items"][0]["devices"][0].startswith("PUB-")
+
+    slack = webhooks.build_payload(result, "raw <!channel>", "slack", "high")["text"]
+    assert "TopSecretRO" not in slack
+    assert "<!channel>" not in slack
+    assert "&lt;!channel&gt;" in slack
+
+
 # ── delivery ─────────────────────────────────────────────────────────────────
 
 class _Resp:


### PR DESCRIPTION
### Motivation
- Outbound webhook payloads included analysis-derived `description` and `devices` fields without sanitization, which could leak raw log secrets such as SNMP community strings. 
- Slack-formatted notifications also emitted raw mrkdwn-sensitive text (e.g. `<!channel>`), which could trigger mentions or link parsing. 
- The intent is to preserve the existing webhook behavior while ensuring secrets/PII are redacted and Slack markup is neutralized before transmission.

### Description
- Import and reuse the existing sanitizer by adding `from ai_log_analyzer.sanitize import sanitize` and a helper `def _sanitize_text(...)` that calls `sanitize(..., mask_pii=True)` to redact secrets and PII. 
- Add `_slack_text(...)` to escape `&`, `<`, and `>` and apply it to all Slack-visible fields so mentions/links are neutralized. 
- Apply sanitization to action-item fields (`severity`, `category`, `description`, and `devices`) and to the generic payload `input`/`source` field while preserving payload shapes and delivery semantics in `build_payload` and `notify_analysis` (`src/ai_log_analyzer/webhooks.py`). 
- Add a regression test that verifies SNMP community secrets are redacted, public IPs are replaced with stable tokens, and Slack mentions are escaped (`tests/test_webhooks.py`).

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_webhooks.py` and the new regression test passed. 
- Ran the full test suite with `PYTHONPATH=src pytest -q` which completed successfully. 
- Ran static checks with `ruff check src/ai_log_analyzer/webhooks.py tests/test_webhooks.py` and `git diff --check`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89c131c832f959db19d46503bbc)