### PR TITLE
redact sensitive credentials in bundled site configs and add regression test

### DIFF
--- a/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf1.txt
+++ b/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf1.txt
@@ -5,7 +5,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$d6EMT.RiEDSYxCO0$EAJPlA7IIOOTHP1n7DO5C1BbsoIvLj0YmY2TfNVlruGYUBCOeJO0OWWfKEli226rD9n4KqD5ibiQ3D5Ud8zpF.
+username admin privilege 15 role network-admin secret sha512 <redacted>
 !
 management api http-commands
    no shutdown

--- a/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf2.txt
+++ b/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf2.txt
@@ -1885,7 +1885,7 @@
                     ]
                 }
                 linuxadmin-user {
-                    password $y$j9T$XvJnmFLaz/uudk.SUG0.J0$K4un1F9/0nyiPJmBAPKhWooaRb7bKSkeItXyVnnlTSC
+                    password <redacted>
                     ssh-key [
                         "<REDACTED-SSH-KEY>"
                     ]
@@ -1911,7 +1911,7 @@
         }
         tls {
             server-profile clab-profile {
-                key $aes1$ATTE3aWsWlxdLW8=$TTZ9x1CJMxkAdXaCNy5KzttSxuHEB1BgKKpF5mIEliemEc+98wXbngG6rOaWeSuUxoE2O8DSQwPVWj1ST+9iHYJ1IpR2ehSY3k2KST/Ou3reeak1q1V2hgVxd6SUdMOh2fynhPUEKa9uVEZLHH3zYhOfyO0O5USt7dlHF3Dyou62p0XOj98UwqcwRsge5jnYmQzaXSyTjEI3ABFsGjyvXNAXkkqjjYTJuuPPGYpvbVyW4sEzC0gHM8Br3UwfssC2Md9lmedYji/Q7Hj2+rwTKysKnYLSkL/jydEkokc21B4JvFcCnMusIhBrfkpWtLOIsn6YFgWk9Of6AkGbcg8sGXS56J21o+zCZw2cZvhT9HAuBPELDWJ1sLfZgwW4FKErPXEh3CvRgvTLzNOQbC0NCg97Uui0g8Jz3BmjvfEz+D/OPFh2RszGIKVWGp+UjruKiOBewOBLtLKMfeu9rcQSTTVAa60vscBZsUs9aGK3o5k8L89AV5tbUQ5QolMeYME8IuD3abQ1EvH2lFKR+/rq2ONHp3j2qkAsj1rGk7cl3iSYojCzNiCE2U0JvnSKQzPwA+SQnHhdXxCECEi8emoc2Byr/VtwJwVHyC6F9AhSS+L05htK1fNjLU5+qrATd2sOq5/ULn9WeytOwDaaC3H+dUiFTz4AmF6Wlx9zNDhBZ+Otg/xQjXwvpP17+9OALa75dtdRO2lkKdpuu+L0JifLEWB2SRXMFSTniw9XYN90E2tIU5rs/duBjlyWsGHzpFKVz+t3pyMcdXHn3B3eK2oZ8Q4XcT1gIz+Ht3WQtX1/wGU7/mTJWgdau3iXW2EZPG861HO9QoITJuJlhT4Gzs2S2AytRI3R3XVC8qBvMyFnxi62Bomk/DkXeDZzqr7y3UlxqSDo/E9dOlSrQk82HmQ7tCmXzsD1g1BdM7lxvR8DczQJQkqVj5Mgp4osMtC7vAUTIRzHnBXjahY/zXCE4PvZ//UATwNF0CH5mTM8SBKWGCfWExq5NFSOijFiG9kvk9fLg3RgL2uKb6CxMcj5bp1Ho16+w6ikHfdy4rzqVV+nO1JwucIHGwv+VF0WzxEuwqmyXVGxJzLxz8e1lNGZKSQS851KIS2ey5dc40iU0KJ7KecrvJOyENRSN39ZGFSv4+/eEySQWHe5aT4/hpO8mI+t71sJrGat+OS2VL/mHn7O3uOvOuvI+a0XGNdY8b9wRbJ7LPokUyit3p2PZYHXIYcs6C8HjcDdXfNqs/P+FHzWBAA1vd6om+eJsQc1ahQ4siIwGGzLgNIYx4Lx1Y0DTmrY+SDCWzsbRKYyzOCnA8sbqisJpELIK9frHUzSKLu57q7QtiPzDUfwY2NdTwlNgFpe6J/NxamVpjkVNDANNvxVPpP5gXzw3/JitfLNIq1yc0IPWQMlr9o3v9ywqsyXWKIJLkg2JWw4+k9PCENQAjBoZtPSXoWrS2kLclINo6YP9BSJ1V1x5vyiwZ2pWb7rDcVtOgxqCBeo9NY++93U67h4rGvEfrQenou9w51cxjIX+CKmwCSBCudlwer7S06qKzWTJtT1Qjd8SExmyx8VzMn5kyvknkzR4VnUMojxzQPWmpv8OCEP+LcA5gTvwvjTx7WUDbP7ptpFalvrVcgAlhEJyM4AZq5QPzSKPK+OQVs6wur0OYEMY4QvR8xpoHEuWZnEkvrIIflEKTdUEUw0xK4a/WQXScUYjSlsA7QwzMheOSXkgwBVgO1uobOo08zp8h6uFFGgM7rIJdS3GeGuiILwtwzJseGGiG4H4SFexi5OYqMFqPwdgS4hHjWRG/IbqYdqY1tYmwYE5vtFcKQB2RHwBSjkAeQEhd9YZGzsPi9Wr/ImKjDGNhD4c3iI8Jnq11AQ4l4tgkPWSI3dKmn0nZ2LZfbRxYDS2APi6jOmG6pAnGrcm9Z+Ie8buypuX9JFXxZXwOGtHz+SNePGazQM5Zn+g8CLnGcTzO0pu+0oqlVHHkPBNnMQLegPja7219BhwNKakoYheXWThsWzl147mtdcnpbEXfkn8HIoBLDV5707ufH5MFbAv6VJgBg8mjlsXfq1WRyMnAvt915KJ+ofaFmDrLvsCxX3Mnrlpcb++bW4RiiyxLThDS91C3u3TuhUekN5IJO3HgJhkvfH3ry+1cKlKzvn7CWYYxXFRCl1QOZhftp/ZbhMA4aRugAR5xzJoRBfHaPW7g2lrBNv+ByjCHVWRiPOrXYfADjc1cHxai9KnFJF
+                key <redacted>
                 certificate "-----BEGIN CERTIFICATE-----
 <REDACTED-CERTIFICATE>
 -----END CERTIFICATE-----
@@ -2023,7 +2023,7 @@
             access-group SNMPv2-RO-Community {
                 security-level no-auth-no-priv
                 community-entry RO-Community {
-                    community $aes1$AWDBWSuwhlrn+28=$Xz9nG2YCQ3Ede49oLViu+Q==
+                    community <redacted>
                 }
             }
             network-instance mgmt {

--- a/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf4.txt
+++ b/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf4.txt
@@ -5,7 +5,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$ZlhQ9l8CDW1m5c/Z$sS2ZpHynAK/C3rPS1OdnMM2n7QuDqEk9/ogokntDdnkBg5IGLu/qMvj0ah0XRNnwcnNrjPvFsEFw4j0dfGU2q1
+username admin privilege 15 role network-admin secret sha512 <redacted>
 !
 management api http-commands
    no shutdown

--- a/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf5.txt
+++ b/src/ai_log_analyzer/data/sites/clab-clos-evpn/leaf5.txt
@@ -1885,7 +1885,7 @@
                     ]
                 }
                 linuxadmin-user {
-                    password $y$j9T$XvJnmFLaz/uudk.SUG0.J0$K4un1F9/0nyiPJmBAPKhWooaRb7bKSkeItXyVnnlTSC
+                    password <redacted>
                     ssh-key [
                         "<REDACTED-SSH-KEY>"
                     ]
@@ -1911,7 +1911,7 @@
         }
         tls {
             server-profile clab-profile {
-                key $aes1$ATC9nGpTSCuNUm8=$k6eYboQ9TKuILFp76WugkoOPNs/AWwyXQxLOnPCYiiDUtht2vQU/KXvbUMNoNFuS+IAkAhtiz7IGnMbEXFDmmRKjLmN+XoRnuOz9B/oazBL5MVx3lcHXiitAF4tj6+ElrhjsGTIFEFEZux5qlnEslwF4/mc8w5GppPCjvjd2AQnJ2uzFZsoyFq8p8fvSwS6UNNeV8gr9Xr/5NDq6ZqjjsOxt7ocDKC9UeW/V48FIicobAl0ILjqdVqIoClE4a+5xrUBYdevNf1PbIMpCpXLOOXHrllQiUEckhz5HSOgMZ0Q1QuOWVbJ+SpGFaGM1POhzCBcmDzMSsmcGB7w3EOSUWfxOgWjw0H4BRz9GaZO/TXqJ/xo2wy/dsn8cb7cH7oGF7UIzWHBejdjw0q8kbhBV+r6auqF9TkPOYWccsbeLwy7xa7/rblfSgmvdG/w30rOt6vYchD+KkMbXzMsh5trU5ySDzMxHEs8Arx7E+FdSwfo9b7Bx1yP8IjdSbdqTGhJfLs9rdq2z+2FvC3QyMInbswakygNLGKip19KcKbXF7rWGqAOm5Mw4uhQkSOW0Xz5Pqu3JEagXRbtpj1033evsrL63W0VrzV8otjZyitz8jXvaf1aU3tP03Sb7Qv1k8e4Gk0gzhbgxIGVEMSHl3PpwLWOihEu/Dm/8oyasb4a1s7vFibT9Ze37uXsecPnMWrH0CFt5cBuNX2KoKfEWHim9Fdft5WbDnucvU3qVBPByP1BEPIlozhgS3ACHO1qsljikl9vmMmmiWbPHHqNkoslAtRmz8qDijzSwq3i1nvrSZ0rBNYcoIb8cMifqKSkcy72sI+iqAU8GZf4bzpQCetx+4w261tz+0lXa80+wK/fPm/uWmvxfgk9l0DeTjgmvuGK0bfO1IpaGE3mT59o7LjqC61BBaHuIwlnNyYtGL40AKZ+YqcgdZ5rQAIQ7U4GceF+fpZBmZBf7c0MOIf1gxV+t5pDCJg+ZVjeO84w5R/gt9/PokzZXIoWDf5ENoYGDVeHYCxNAhfHdeSWsYjOM5OTNBJgcjYhE4ZliQyF6h7Uk+HytTVIu65GK3qxTDJYbpie//MVKH/7yVqKxrHe+vMmIKaXhcFK+B/mFqbUWEUZRZ3LwQbnsFiKPW2OwxoIxjlp0JNdpwLknaQueA1OwtN/PZXNyVjH5ObXfgoKrpxVmnJebgveTzxLn/bFy6Zmp5l1JMjIeRfrjGscNrsO23PGONxWlKPD5z/wm6bj71ASvWhDieIRru805WrMXvVe0en9nBPCW2pSVtQOZ0Uznz3VU2BnXLJ9JSRhg+tvPTj7kITF8tCzQJPK/6KYoQb5TGyKj76/vmhO4YaCcLbfxItHuGRmQDQ4Ch7Qby3bbSTauRhRdNzZEh2FgiV2yTPAxNfp58q+NoNGxgp4yQbTN5J16/SyHeQqNo27vTbbQIatdCWTnrVGaXUeGzmNnhaarbba/pdExwgquIL8GGiswJmUNRcoaEI202NQlYjc0xVi4Fg1aS3EEV7UF3E/RTc6yLYgsmugjHC3uy0Fmq79xp59dk8w4ZY1lU/avHPvARc2XezQt/eslRFVgIo9aq6rTCARTs9DqwKyrgZq9PcZUYL13SiVcIOlODiSqbP2Y+p62QrOUCU819fVVLxF7hy2AFpwI9abV/4hGdoZG+mpDghKvv4350/e5Sooc9+QhjN4PFTftjUNNIINFesBnlXdMMIgHyb7k9SM52UWbsVbdPOgLSvMetaioFQEFptr+Jm8lpS1vATft4wROBaNo4kzu7b3/nsCrSbRUVIbm1Uxvr8OQbkRt1W+WCfh9cy2is0tGqXGdalmPSii8G7KdIeWkWvWopwCPRwKnaI3Cc0zVMLHKFYUE1LfKScNxMHb76Ua14lfz7bACq96AqaVfgtebPU2EiBQ18gCC48IQwutqgOk8G6jSh/G+3flTUz1j3lcIdYtmp87atkzINFsek9OILSyAH/l76s8p+Y6CFLXyLlODD1IlFkrVPZWLW0ov19sIXYk/ygMEdqUMIURKHRKfNDlAAWVtZ9QdEwr0q5CmAGGwq1ByRHtK/xuikry6O/kHwjRsE97vTe21SUhawjdaezeezpAxj8+0JZf/ajR09wcEIE2MmwfncYCEciqc5tJvksdatobZUGFRtuhGJ6urAt5iMVVk8p1ctlMhJoMNPUaiIrg7sbYkFu3QbvgO8KmGDejF4m5gvRTF1/hId1PFL7td
+                key <redacted>
                 certificate "-----BEGIN CERTIFICATE-----
 <REDACTED-CERTIFICATE>
 -----END CERTIFICATE-----
@@ -2023,7 +2023,7 @@
             access-group SNMPv2-RO-Community {
                 security-level no-auth-no-priv
                 community-entry RO-Community {
-                    community $aes1$AWBpAhWLuP1acG8=$A6lGNrYiHPX93kJSaDly/g==
+                    community <redacted>
                 }
             }
             network-instance mgmt {

--- a/src/ai_log_analyzer/data/sites/clab-clos-evpn/spine1.txt
+++ b/src/ai_log_analyzer/data/sites/clab-clos-evpn/spine1.txt
@@ -1942,7 +1942,7 @@
                     ]
                 }
                 linuxadmin-user {
-                    password $y$j9T$XvJnmFLaz/uudk.SUG0.J0$K4un1F9/0nyiPJmBAPKhWooaRb7bKSkeItXyVnnlTSC
+                    password <redacted>
                     ssh-key [
                         "<REDACTED-SSH-KEY>"
                     ]
@@ -1968,7 +1968,7 @@
         }
         tls {
             server-profile clab-profile {
-                key $aes1$ATCAYFoTT/48FW8=$8Og07in7zKRHo+546ml0qbvUs5ZNLbbV7fFs0VJBGvkwtbOLF36vPFNOcmuhZKgcBMcR8eTT8zlmC3TsflXoOeIpFd01NslvwO69mB7sJaBMbvaXaDehqhvhd0nZnWyXSHHQqWB9oh0c8FzUTzQ4PhAc8zy0fbflNk0VqtzRRh/fuxwQnfvYkvwyjJH8GIuFy8EF47ZLSOz0rwE6t7Jq9USw7d7veI29jv/dn1Le2gbyDSfR16otFGzMHm1CqiANOd8FSmj42XHNkVGVt4OA4/LqmTnX6SrTdydRJ4AYaK2xsBpXAg4+9BdU5vwsmVfotAzQXahnxD/I2xiW1CqyOA7lOIoo1XfJq36NCc8FNCopCvmxN2vy3ntv2Dtd9mb/O+SPbrQXMHxbScFNQVv03R8+f9drUICIMPKdfFQXs7VOIQ9BPssU1fa3qbG21u6YXkcOLZh9nFi6MBRSjBMF0aWS4L+XAAls0FjM0jNa1uvw0XludtrsEtTl9WCyK3JY7QA9cyg3/nKDDz0E5q3HzXf2roYjgF7Qab5sN8LlwF2WXjy55YpWBlWKJGaEtzwPT63ueGgdbzJadjKv+YN4BiCQt3Vu5blxqi9vk4JBhDMM7fhfZYnZxwz9S4hQk44oI+aNX0WVLhItFn1ym4PV7REhgg+VGlpSr6eVkjwnPzetC5DXMcNL3XtRb+5DxY2qOH+igUwljG1wxD2p8PXE19xQ6YM6aPwKpXr29fQePmflgIjsC6iaFd/ZV9zyBQuSgMbGAHh2/ylw4zjC0vXk2DcnjKMzHHAFYwomuth5FxC2LG11CFRgyMtYBMbpuL0ekQ8aEdctLyTiULO1vgpqIEHGWFatWmtkg7oODaMY8w1xagVx9QbOiMS1cJTFJVVYpMVeWnTrzmUjJOFxWKQyMd/TIOyhVdBm+VEWos5DKPuCGHhnjpFijkH2pVjyvmzcgCFPBG7DR249dlKduH79Zpxtp5EADwccEESjXxpcl7oI6GnntB96r4PrlDnc6URIVIQ/YHeVsbB7e98qvpzj3xrw/dbKV9tgeeC1xgIh4bstdGzev52QjZI3wEbOmQG79GdM9HxquFRqB1OPxcFdPuZ9HxqbQ+0uOGImphrfnpgE3oSbEOLQT3kHxKGSkiLoaljtO4SVdznhrgvcmpXvfcb1Ehuc+t3HdjFDBOpTA6qj3IQj8ZMOa1Z6vRLgnicFv6T18BQo7DMG+xHtK9iPMC2ZtwyXOxDtBWwZIfOyctR72IAxY7JPaqV+jigloo1KVE95mgcsJOmfFm0NJjEumIKUkx5wP5bAgN3GiUlAqL0IzHLdtPUcW40jQ5HB24UJQCUyj336X1cUzgsBYioHDikDcntf8Jw0u2eCrGvLZWY+rjZMQge2i5Zx4CPupTdVLjGTzFqf8m6RPsBcYlS/R8XDJ2ZL3iTb10ZIyD2p9OCXcF9BQtVRmOalKTeS2dH9N+oevZltAUhEGKNWJw9YcZXDAkoTMgM1OXRKUtoV6HZ57kRe6k6e90WE9PHYMgaey9+uxoGuKnrKKbG9n3E5JYVmJwkuqiAQ2GPOBNEJTaUx1GaXWxqw2fPa/AT1oAUhrzsGWhVGT6kCnBMfLamm37pcyQuMDkTe13vfvleGEGcBSGAnTuQfi6xay5TB1oCFC/FTeqfM/RrOHTynWHLTx0JI9URNK358oRkc/vcXkbvPfpXt5SCkD4RAFYtPwixx7xvn30gyR5Imue+HNPVPAfEKtOnKJ6nqXZZdfQwC6VaUEGFLnv2NE53qJkZbfGewk4gJEme//EIB1+ra9wdaXd6xGwige4HMCJ1Zu3p8cb16RNCL2oqGGA4b6X+9B8ofhggc2yWN2DI04gYq/0XO8oAuAuZmdZigNFlordHXlpGTLMCMCvBKK/dt0rW8jbAutpAGZzIXxWwfGm/zsuAhtF1e7pyktlr1zDZNkwugjYIon6XWGRMdL9If7EFrjAyhnnE4CszKFzD476DKsAtbRTAqXM3D3H3gvEDVrLYzjVSxFCG8x0n1AqxeA6i5IK8+N2CvLQOO/amLvUAD4eYwf5pDgAIGGLPi9SK6GFtJIFAt5bakEIclyqqRjXK6HWdDL2ydlJYvBG8Tks1HtyQ8IbWoA4fTg/RDhP7+d1lc/vrh6taZEweYb4T6VrUTseS3r7soINj6LBHDdXx5OBeQ1ecQJ1EAv4mbtGLbwxRKFH17HQBZ4x+182RVvDAM7rBT
+                key <redacted>
                 certificate "-----BEGIN CERTIFICATE-----
 <REDACTED-CERTIFICATE>
 -----END CERTIFICATE-----
@@ -2080,7 +2080,7 @@
             access-group SNMPv2-RO-Community {
                 security-level no-auth-no-priv
                 community-entry RO-Community {
-                    community $aes1$AWDtWxLrf+31O28=$69YUYoaESnu9CsLVbxYtUw==
+                    community <redacted>
                 }
             }
             network-instance mgmt {

--- a/src/ai_log_analyzer/data/sites/clab-clos-evpn/spine2.txt
+++ b/src/ai_log_analyzer/data/sites/clab-clos-evpn/spine2.txt
@@ -5,7 +5,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$QyhDcQt9OJp5vgV6$KypFaRgpBWdsuCSzXlJ2Czbeqvplyk1rgrfog6t9gBOjCBh5RYNiSGS8dCdIYYyLdMqc7L/wF3GahdA/flU4P0
+username admin privilege 15 role network-admin secret sha512 <redacted>
 !
 management api http-commands
    no shutdown

--- a/tests/test_data_dirs.py
+++ b/tests/test_data_dirs.py
@@ -6,6 +6,8 @@ and Docker images boot with demo content; env vars override for custom data.
 from __future__ import annotations
 
 
+import re
+
 import pytest
 
 from ai_log_analyzer.web.app import SAMPLES_DIR, SITES_DIR, STATIC_DIR, _data_dir
@@ -48,9 +50,21 @@ def test_samples_stay_pseudonymized():
 
 
 @pytest.mark.unit
+def test_bundled_sites_do_not_contain_credentials():
+    """Public wheels must contain only sanitized site configurations."""
+    credential_patterns = (
+        re.compile(r"\$(?:6|y|aes1)\$(?!REDACTED)"),
+        re.compile(r"-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----"),
+    )
+    for config in SITES_DIR.rglob("*.txt"):
+        text = config.read_text(errors="replace")
+        for pattern in credential_patterns:
+            assert not pattern.search(text), f"{config} contains credential material"
+
+
+@pytest.mark.unit
 def test_index_html_has_no_cdn_scripts():
     """Air-gap guard: the UI must not load JS from external CDNs."""
     html = (STATIC_DIR / "index.html").read_text()
-    import re
     external = re.findall(r'<script[^>]+src="(https?://[^"]+)"', html)
     assert not external, f"external scripts found: {external}"


### PR DESCRIPTION
### Motivation

- Prevent shipping unredacted credential material inside release wheels after `data/sites/**/*` was included as package data by removing raw password hashes, encrypted key blobs and encrypted SNMP/community values from bundled site fixtures.
- Add an automated guard so future changes cannot accidentally reintroduce those secrets into the packaged data.

### Description

- Replace credential values with safe placeholders (e.g. `<redacted>` or `<REDACTED-SSH-KEY>` / `<REDACTED-CERTIFICATE>`) in bundled site files under `src/ai_log_analyzer/data/sites/clab-clos-evpn/` (modified: `leaf1.txt`, `leaf2.txt`, `leaf4.txt`, `leaf5.txt`, `spine1.txt`, `spine2.txt`).
- Add `test_bundled_sites_do_not_contain_credentials` to `tests/test_data_dirs.py` which uses regular expressions to detect non-placeholder password hashes (`$6$`, `$y$`), encrypted-secret markers (`$aes1$`) and private-key PEM headers to ensure site configs remain sanitized.
- Import `re` and reuse the existing test module layout so the new guard runs with the other data-dir packaging tests.

### Testing

- Ran the targeted tests with `PYTHONPATH=src python -m pytest tests/test_data_dirs.py` and observed `7 passed`.
- Ran the full test suite with `PYTHONPATH=src python -m pytest` and observed `374 passed, 2 skipped`.
- Verified via repository searches that credential markers were replaced with `<redacted>` placeholders in the modified site files.
- Attempted to build/wheel-verify artifacts but the execution environment lacked the `build` module / an importable `setuptools.build_meta` backend, so an on-host wheel sanity-check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89b6df4832fbb1cad187157a404)