### PR TITLE
Fix Unicode case bypass in classifier literal gate

### DIFF
--- a/src/ai_log_analyzer/classifier.py
+++ b/src/ai_log_analyzer/classifier.py
@@ -361,9 +361,11 @@ def iter_classify(events: Iterable[LogEvent]) -> Iterator[ClassifiedEvent]:
                 break
 
         if not desc:
-            # Literal gate: no keyword → only the unproven patterns can possibly
-            # match (their relative order is preserved, so precedence holds).
-            if any(k in combined for k in _KEYWORDS):
+            # re.IGNORECASE has additional Unicode matches that plain lowercase
+            # substring checks do not, so only use the literal gate for ASCII.
+            # No keyword → only the unproven patterns can possibly match (their
+            # relative order is preserved, so precedence holds).
+            if not combined.isascii() or any(k in combined for k in _KEYWORDS):
                 candidates = _COMPILED
             else:
                 candidates = _UNGUARDED

--- a/tests/test_classifier_gate.py
+++ b/tests/test_classifier_gate.py
@@ -55,6 +55,19 @@ def test_guarded_pattern_still_matches():
 
 
 @pytest.mark.unit
+def test_non_ascii_ignorecase_match_bypasses_literal_gate():
+    events = [LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
+                       appname="authd", severity_raw="err",
+                       message="authentıcation faıl")]
+
+    classified, _, _ = classify_events(events)
+
+    assert classified[0].severity == "high"
+    assert classified[0].category == "security"
+    assert classified[0].description == "Authentication failure"
+
+
+@pytest.mark.unit
 def test_unmatched_line_stays_info():
     events = [LogEvent(timestamp="2026-01-01T00:00:00", hostname="r1",
                        appname="cron", severity_raw="info",


### PR DESCRIPTION
### Motivation

- The literal fast-path gate used plain lowercasing and `str.__contains__` on the combined log text while the KB regexes are compiled with `re.IGNORECASE`, which has Unicode case-matching semantics and can match characters like dotless-i (U+0131) that a plain ASCII substring check will miss. 
- The change prevents security-relevant regexes (e.g. authentication-failure rules) from being skipped for non-ASCII log text, preserving classification correctness.

### Description

- In `src/ai_log_analyzer/classifier.py` the literal gate was restricted to ASCII input by checking `not combined.isascii()` and routing non-ASCII text to the full ordered regex table so `re.IGNORECASE` semantics are preserved. 
- Added a regression test `test_non_ascii_ignorecase_match_bypasses_literal_gate` to `tests/test_classifier_gate.py` that verifies an authentication-failure message containing dotless-i characters is classified as `high/security`. 
- Only two files were modified: `src/ai_log_analyzer/classifier.py` and `tests/test_classifier_gate.py`, and the change is a minimal behavioral gate adjustment that preserves the original semantics for ASCII inputs while avoiding unsafe bypasses for non-ASCII inputs.

### Testing

- Ran `git diff --check` which reported no problems. 
- Ran `PYTHONPATH=src pytest -q tests/test_classifier_gate.py` and the test module passed. 
- Ran the full test suite with `PYTHONPATH=src pytest -q` and all tests passed. 
- Ran `ruff check .` with no lint failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89b64ec832fb92197153a6345e5)