### PR TITLE
Bound Executive Summary hostname anchors

### DIFF
--- a/src/ai_log_analyzer/analyzer.py
+++ b/src/ai_log_analyzer/analyzer.py
@@ -464,11 +464,17 @@ def _executive_summary(
     use_llm: bool,
 ) -> tuple[list[str], bool]:
     if use_llm:
-        # Collect the real hostnames from validated action items — single source
-        # of truth for the LLM. Anything outside this list is a hallucination.
+        # Keep hostname anchoring aligned with the bounded action-item details
+        # below.  Do not serialize every action item's devices: callers can
+        # create many distinct action items and otherwise grow the LLM prompt
+        # without bound.
+        anchor_items = items[:5]
         allowed_hostnames = sorted({
-            h.lower() for a in items for h in (a.devices or []) if h
+            h.lower() for a in anchor_items for h in (a.devices or [])[:5] if h
         })
+        omitted_hostnames = sum(len(a.devices or []) for a in items) - sum(
+            min(5, len(a.devices or [])) for a in anchor_items
+        )
         sys_prompt = (
             "You are a senior network engineer writing a 4-6 bullet executive summary for a "
             "network operations standup. Each bullet must be specific (with device names + numbers), "
@@ -486,6 +492,7 @@ def _executive_summary(
         ]
         user_prompt = (
             f"ALLOWED_HOSTNAMES (use only these exact names): {allowed_hostnames}\n\n"
+            f"Additional hostname references omitted: {omitted_hostnames}\n"
             f"Score: {score}/100 (grade {grade} — {grade_label})\n"
             f"Severity: critical={sev_counts.get('critical', 0)}, "
             f"high={sev_counts.get('high', 0)}, medium={sev_counts.get('medium', 0)}\n"

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -251,6 +251,39 @@ def test_executive_summary_llm_prompt_anchors_hostnames(monkeypatch):
 
 
 @pytest.mark.unit
+def test_executive_summary_caps_hostname_anchors(monkeypatch):
+    """Attacker-amplified action items must not grow the LLM hostname list."""
+    from ai_log_analyzer import llm
+    from ai_log_analyzer.analyzer import ActionItem, _executive_summary
+
+    captured = {}
+
+    def fake_query(system: str, user: str, max_tokens: int = 400) -> str:
+        captured["user"] = user
+        return "• Investigate the top affected devices"
+
+    monkeypatch.setattr(llm, "query", fake_query)
+    items = [
+        ActionItem(severity="high", category="routing",
+                   description=f"Unique failure {i}", count=1,
+                   devices=[f"host{i:03d}"], sample_messages=[])
+        for i in range(100)
+    ]
+
+    _executive_summary(
+        sev_counts={"critical": 0, "high": 100, "medium": 0},
+        cat_counts={"routing": 100},
+        score=0, grade="F", grade_label="Critical",
+        items=items, use_llm=True,
+    )
+
+    hostname_line = captured["user"].splitlines()[0]
+    assert "host000" in hostname_line and "host004" in hostname_line
+    assert "host005" not in hostname_line and "host099" not in hostname_line
+    assert "Additional hostname references omitted: 95" in captured["user"]
+
+
+@pytest.mark.unit
 def test_executive_summary_scrubs_placeholders_in_llm_output(monkeypatch):
     """LLM that still emits R1/SW2 → bullet gets [hostname?] substitution."""
     from ai_log_analyzer import llm


### PR DESCRIPTION
### Motivation
- The Executive Summary LLM prompt previously serialized every action-item hostname into `ALLOWED_HOSTNAMES`, which allowed an attacker to grow the prompt linearly and force oversized LLM calls (context overflow, worker tie-up, cloud cost).
- The change restores a bounded, predictable prompt size while preserving hostname anchoring and fleet context.

### Description
- Limit the hostname anchors to the top five action items and at most five device names per action item when building `ALLOWED_HOSTNAMES` in `_executive_summary` in `src/ai_log_analyzer/analyzer.py`.
- Add an `omitted_hostnames` aggregate count and include it in the user prompt so the LLM keeps fleet-size context without serializing attacker-controlled hostnames.
- Keep existing LLM prompt shape and post-validation (`_scrub_placeholders`) unchanged so the operator-visible behavior is preserved.
- Add a regression test `test_executive_summary_caps_hostname_anchors` in `tests/test_analyzer.py` that constructs 100 unique action items and asserts the prompt contains only the bounded anchors and the omitted count.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_analyzer.py`, and the unit tests passed. 
- Ran `ruff check src/ai_log_analyzer/analyzer.py tests/test_analyzer.py`, and lint checks passed. 
- Ran `PYTHONPATH=src pytest -q` (full test suite), and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89cb3e0832f924195997ef37dae)