### PR TITLE
fix: sanitize persisted log templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 # Path to a JSON store remembering every mined template shape across runs.
 # When set, templates never seen in any prior run are flagged 🆕 in the
 # Unknown Patterns panel and counted as new_template_count in /api/analyze.
+# Stored templates are secret-sanitized and the file is forced to owner-only access.
 #AI_LOG_ANALYZER_TEMPLATE_STORE=~/.cache/netlog-ai/templates.json
 
 # ── Incident memory (optional) ────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to **netlog-ai** are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/); this project uses
 loose semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- Secret-sanitize cross-run template memory before persistence and force its JSON
+  file to owner-only permissions.
+
 ## [0.5.1] - 2026-07-28
 
 Packaging hotfix. **`pip install netlog-ai[all]` and `pip install netlog-ai[parse]`

--- a/src/ai_log_analyzer/patterns.py
+++ b/src/ai_log_analyzer/patterns.py
@@ -29,6 +29,8 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .sanitize import sanitize
+
 logger = logging.getLogger(__name__)
 
 # Masking rules applied before tokenization, most specific first.
@@ -125,7 +127,8 @@ class TemplateMiner:
 
     def add(self, message: str, hostname: str = "") -> TemplateCluster:
         """Feed one raw message; returns the cluster it joined or created."""
-        masked = mask_message(message.strip())
+        safe_message, _ = sanitize(message.strip())
+        masked = mask_message(safe_message)
         tokens = masked.split()
         if len(tokens) > self.max_tokens:
             tokens = tokens[: self.max_tokens]
@@ -230,7 +233,8 @@ class TemplateStore:
         if isinstance(data, list):
             for t in data[-self.max_entries:]:
                 if isinstance(t, str):
-                    self._templates[t] = None
+                    safe_template, _ = sanitize(t)
+                    self._templates[safe_template] = None
 
     def __contains__(self, template: str) -> bool:
         return template in self._templates
@@ -243,7 +247,7 @@ class TemplateStore:
         templates into the store, and return the new-template count."""
         new_count = 0
         for cluster in miner._clusters.values():
-            t = cluster.template
+            t, _ = sanitize(cluster.template)
             if t not in self._templates:
                 cluster.is_new = True
                 new_count += 1
@@ -258,8 +262,14 @@ class TemplateStore:
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-            tmp.write_text(json.dumps(list(self._templates)), encoding="utf-8")
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(tmp, flags, 0o600)
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as store_file:
+                json.dump(list(self._templates), store_file)
             tmp.replace(self.path)
+            self.path.chmod(0o600)
         except OSError as exc:
             logger.warning("could not persist template store to %s: %s", self.path, exc)
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,9 @@
 """Tests for the unknown-pattern template miner (patterns.py)."""
 from __future__ import annotations
 
+import json
+import stat
+
 import pytest
 
 from ai_log_analyzer.patterns import TemplateMiner, mask_message
@@ -144,6 +147,23 @@ def test_template_store_flags_new_templates_across_runs(tmp_path):
     by_template = {c.template: c for c in m2.top(10)}
     assert by_template["thermal envelope exceeded on chip <n>"].is_new is False
     assert by_template["gravity plating desynchronized"].is_new is True
+
+
+def test_template_store_redacts_secrets_and_uses_owner_only_permissions(tmp_path):
+    from ai_log_analyzer.patterns import TemplateStore
+
+    store_path = tmp_path / "templates.json"
+    miner = TemplateMiner()
+    miner.add("maintenance neighbor 192.0.2.10 password 7 FakeCredentialValue")
+
+    store = TemplateStore(store_path)
+    store.mark_and_update(miner)
+    store.save()
+
+    persisted = store_path.read_text(encoding="utf-8")
+    assert "FakeCredentialValue" not in persisted
+    assert "<REDACTED>" in json.loads(persisted)[0]
+    assert stat.S_IMODE(store_path.stat().st_mode) == 0o600
 
 
 def test_template_store_bounded_and_corrupt_file_tolerated(tmp_path):


### PR DESCRIPTION
### Motivation

- Prevent cross-run template persistence from storing unredacted secret-like fragments mined from unclassified logs and from being written with permissive file permissions.

### Description

- Sanitize raw log messages before masking/mining by calling `sanitize()` in `TemplateMiner.add()` so secrets are redacted before templates are created. 【F:src/ai_log_analyzer/patterns.py†L128-L132】
- Sanitize templates when loading an existing store (`TemplateStore._load`) and when marking/updating (`mark_and_update`) so persisted/loaded entries are always sanitized. 【F:src/ai_log_analyzer/patterns.py†L225-L237】【F:src/ai_log_analyzer/patterns.py†L245-L254】
- Harden atomic persistence in `TemplateStore.save()` by creating the temp file with `os.open()` and mode `0o600`, using `os.fchmod()` and `json.dump()` to write the file, replacing it atomically, and enforcing `0o600` on the final file. 【F:src/ai_log_analyzer/patterns.py†L259-L274】
- Add a unit test that asserts secret values are not present in the persisted store and that the persisted file has owner-only permissions, and update `.env.example` and `CHANGELOG.md` to document sanitization and permission guarantees. 【F:tests/test_patterns.py†L152-L166】【F:.env.example†L42-L47】【F:CHANGELOG.md†L7-L12]

### Testing

- Ran `PYTHONPATH=src python -m pytest -q tests/test_patterns.py` and the added regression test passed. ✅
- Ran full test suite `PYTHONPATH=src python -m pytest -q` and it completed successfully. ✅
- Ran lint checks `python -m ruff check .` which succeeded. ✅
- Ran repository checks `git diff --check` which reported no issues. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89dba28832fae7023d5197ab4ff)