### PR TITLE
fix: bound TextFSM demo template scan

### DIFF
--- a/demo/tfsm_demo.py
+++ b/demo/tfsm_demo.py
@@ -74,6 +74,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
 
     hdr("Threshold filtering (min_score=40 in production)")
     r = auto_parse("random log line nothing structured here at all",
+                   filter_hint="lldp_neighbor",
                    min_score=40.0)
     show("matched", r.matched)
     show("score", f"{r.score:.1f}")

--- a/tests/test_tfsm_demo.py
+++ b/tests/test_tfsm_demo.py
@@ -1,0 +1,23 @@
+"""Regression tests for the TextFSM terminal demo."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from demo import tfsm_demo
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_demo_limits_every_template_scan(capsys: pytest.CaptureFixture[str]) -> None:
+    """Even unstructured demo input must not scan the full template database."""
+    result = SimpleNamespace(template=None, score=0.0, records=[], matched=False)
+
+    with patch.object(tfsm_demo, "auto_parse", return_value=result) as auto_parse:
+        assert tfsm_demo.main() == 0
+
+    assert all(call.kwargs.get("filter_hint") for call in auto_parse.call_args_list)
+    capsys.readouterr()


### PR DESCRIPTION
### Motivation
- The demo used `auto_parse()` on an unstructured sample without a `filter_hint`, which triggers a full TextFSM template database scan that can take many minutes and produced a misleading high-confidence match in the recorded demo.

### Description
- Constrain the threshold demo parse by passing `filter_hint="lldp_neighbor"` to the `auto_parse()` call in `demo/tfsm_demo.py` so the adapter performs a bounded, fast scan.
- Add a regression test `tests/test_tfsm_demo.py` that patches `tfsm_demo.auto_parse` and asserts every demo invocation supplies a non-empty `filter_hint` to prevent reintroducing the unbounded-scan behavior.
- This change does not alter the `tfsm_auto` adapter API or production parsing behavior; it only limits the demo/recording path.

### Testing
- Ran the focused regression test with `PYTHONPATH=src pytest -q tests/test_tfsm_demo.py` and it passed. 
- Ran the full unit suite with `PYTHONPATH=src pytest -q` and it passed. 
- Executed the demo with `PYTHONPATH=src python demo/tfsm_demo.py` which exited `0` and produced the expected output. 
- Performed static checks including `python -m compileall`, `ruff` on the modified files, and `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c89b4b90832f87b6648adfdf1476)