### PR TITLE
release: 0.5.2 — security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ loose semantic versioning.
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-23
+
+Security and hardening release.
+
 ### Fixed
 
 - Bind `/api/analyze` (`source=frr`) and the `/api/optimize` docker-exec fallback
@@ -15,6 +19,19 @@ loose semantic versioning.
   `dev-*` / `us-east-*` containers cannot ride a country-level allow-list.
 - Secret-sanitize cross-run template memory before persistence and force its JSON
   file to owner-only permissions.
+- Protect incident search endpoints (`/api/incidents/similar`) with the API token.
+- Bound custom classification regexes to prevent ReDoS.
+- Sanitize outbound webhook payloads.
+- Redact credentials from bundled site configuration samples.
+- Fix Unicode casefold bypass in the classifier literal gate.
+- Bound executive-summary hostname anchors.
+- Bound TextFSM demo template scan.
+
+### Notes
+
+- The MCP extra is already `mcp>=2,<3` on main (server code ported to
+  `mcp.server.mcpserver.MCPServer`). Formal packaging/test lock-in remains in
+  open PR #33 and will ship in a follow-up release.
 
 ## [0.5.1] - 2026-07-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netlog-ai"
-version = "0.5.1"
+version = "0.5.2"
 description = "AI-powered network syslog analyzer with pluggable LLM providers (local Docker Model Runner / Anthropic Claude) and lab adapters."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Prepares the **0.5.2** security/hardening release.

### Changes
- Bump `version` in `pyproject.toml` to `0.5.2`
- Move all post-0.5.1 security work into a proper `## [0.5.2] - 2026-08-23` section in `CHANGELOG.md`
- Clear the previous Unreleased items

### Included fixes (already on main)
- Docker container allow-list for `/api/analyze` + `/api/optimize` (PR #32)
- Incident journal search requires API token
- ReDoS bounds on custom classification rules
- Sanitize outbound webhook payloads
- Redact credentials from bundled site configs
- Unicode casefold bypass in classifier
- Bound executive-summary hostname anchors
- Secret-sanitize + owner-only perms on template store
- Bound TextFSM demo template scan

### Notes
- MCP extra is already `mcp>=2,<3` on main. Formal packaging/test lock-in remains in open PR #33 and is intentionally left for a follow-up.

### After merge
```bash
git checkout main && git pull
git tag v0.5.2
git push origin v0.5.2
```
The existing `release.yml` will build, smoke-test, publish to PyPI via Trusted Publishing, and create the GitHub Release.