### PR TITLE
docs: ship v0.6.0 causal console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ loose semantic versioning.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-29
+
+Causal console release.
+
 ### Added
 
 - **xAI Grok LLM provider** (`LLM_PROVIDER=grok`, `XAI_API_KEY`) — OpenAI-compatible

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [![CI](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/gesh75/netlog-ai/actions/workflows/ci.yml) ![Tests](https://img.shields.io/badge/tests-423%20passing-brightgreen) ![License](https://img.shields.io/badge/license-MIT-blue) ![Python](https://img.shields.io/badge/python-3.10%2B-blue) ![Stack](https://img.shields.io/badge/stack-Flask%20%2B%20vanilla%20JS-1f6feb)
 
-> 📓 Recent changes — cross-source correlation + per-device triage (MCP tools **and** Device-tab UI) — are in [`CHANGELOG.md`](CHANGELOG.md).
+> 📓 Recent changes — **0.6.0 causal console** (Grok, timeline, blast radius, SONiC/Cumulus) — are in [`CHANGELOG.md`](CHANGELOG.md).
 
 ---
 
@@ -31,6 +31,17 @@ Most "AI for ops" tools either ship your data to a SaaS or hide what the model a
 - Built for **multi-vendor reality** — not a Cisco-only tool retrofitted with a chatbot.
 
 If you have ever watched an AI dashboard hallucinate a "root cause" with no actionable next step, this is the antidote.
+
+## What's new — 0.6 causal console
+
+v0.6.0 (2026-08-29) ships the causal console on top of the 0.5.2 security tree:
+
+- **xAI Grok** as a first-class sanitize-first LLM backend (`LLM_PROVIDER=grok`, `XAI_API_KEY`)
+- **Causal timeline**, **blast-radius estimator**, and **change-window correlator** on every `analyze()` — Flask, CLI, and MCP share the same fields
+- **Sanitize-diff** (`POST /api/sanitize-diff` + UI) so you can see exactly what the model is allowed to see
+- **Custom-rule editor** in the Flask UI
+- **SONiC + Cumulus** classifier patterns (orchagent / syncd / SWSS / teamd, clagd / switchd / NVUE / PTMD)
+- Suite **423 tests**. Docs: <https://gesh75.github.io/netlog-ai/>
 
 ## What's new — connectors + MCP server
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,13 +5,15 @@
 # 🏛️ netlog-ai — Architecture
 
 **netlog-ai** is a local-first, multi-vendor network log analyzer. It ingests syslog and CLI output from
-Junos, Arista EOS, Nokia SR Linux and FRR (via pluggable connectors or local adapters), classifies events with a
-~60-pattern regex knowledge base, deduplicates them into a severity-ranked action list, and lets an LLM
-(local Ollama / Docker Model Runner, or Anthropic Claude) write a 5-phase root-cause playbook with
-copy-pastable per-vendor CLI fixes. Its defining invariant is **sanitize-before-LLM** — every config and log
-is scrubbed of secrets and public IPs before any outbound call — and it degrades gracefully to a deterministic
-rule-based KB when no model is available. The same analyzer core is exposed three ways: a no-build Flask +
-vanilla-JS dashboard (port 6060), a CLI, and an MCP server for agent clients like Claude Code.
+Junos, Arista EOS, Nokia SR Linux, Cisco IOS-XE / NX-OS, SONiC, Cumulus and FRR (via pluggable connectors
+or local adapters), classifies events with an 80-pattern regex knowledge base, deduplicates them into a
+severity-ranked action list, and lets an LLM (local Ollama / Docker Model Runner, Anthropic Claude, or
+xAI Grok) write a 5-phase root-cause playbook with copy-pastable per-vendor CLI fixes. Its defining
+invariant is **sanitize-before-LLM** — every config and log is scrubbed of secrets and public IPs before
+any outbound call — and it degrades gracefully to a deterministic rule-based KB when no model is available.
+The same analyzer core is exposed three ways: a no-build Flask + vanilla-JS dashboard (port 6060), a CLI,
+and an MCP server for agent clients like Claude Code. v0.6.0 adds a causal console (timeline, blast
+radius, change-window correlator) plus a sanitize-diff viewer.
 
 ---
 
@@ -40,8 +42,8 @@ flowchart TB
     AGENT["AI Agents - Claude Code and Cursor"]
     NET(["netlog-ai analyzer core"])
     LOGS["Log Platforms - Kibana, Splunk, Loki, LibreNMS, syslog"]
-    LLM["LLM Runtimes - Ollama, Docker Model Runner, Claude"]
-    DEV["Network Devices - Junos, EOS, SR Linux, FRR"]
+    LLM["LLM Runtimes - Ollama, Docker Model Runner, Claude, Grok"]
+    DEV["Network Devices - Junos, EOS, SR Linux, FRR, SONiC, Cumulus"]
 
     OP -->|HTTP and JSON| NET
     AGENT -->|MCP stdio| NET
@@ -77,7 +79,7 @@ flowchart TB
     subgraph ENTRY["Entrypoints"]
         WEB["web/ - Flask plus vanilla-JS SPA, port 6060, ~30 api routes"]
         CLI["cli.py - serve, analyze, mcp"]
-        MCP["mcp_server/ - FastMCP stdio"]
+        MCP["mcp_server/ - MCPServer stdio"]
     end
 
     subgraph INGEST["Ingest"]
@@ -87,8 +89,9 @@ flowchart TB
 
     subgraph CORE["Analyzer Core"]
         SAN["sanitize.py - redact gate"]
-        CLS["classifier.py - ~60 regexes"]
+        CLS["classifier.py - 80 regexes"]
         ANA["analyzer.py - orchestrator"]
+        CAU["causal.py - timeline, blast, change-window"]
         SITE["site intelligence - topology, optimize, copilot"]
     end
 
@@ -100,6 +103,7 @@ flowchart TB
     WEB & CLI & MCP --> ANA
     SRC & ADP --> ANA
     ANA --> SAN --> CLS
+    ANA --> CAU
     ANA --> SITE
     ANA --> LLMC
     LLMC -.fallback.-> KB
@@ -113,7 +117,7 @@ flowchart TB
     class WEB,CLI,MCP entry
     class SRC,ADP in
     class SAN gate
-    class CLS,ANA,SITE core
+    class CLS,ANA,CAU,SITE core
     class LLMC,KB brain
 ```
 
@@ -132,18 +136,21 @@ sequenceDiagram
     participant API as Flask /api/analyze
     participant AN as analyzer.analyze
     participant CL as classifier
+    participant CA as causal
     participant SA as sanitize
     participant LK as llm and kb
 
     OP->>API: POST logs or site bundle
     API->>AN: analyze events and use_llm
-    AN->>CL: strip_ansi plus classify ~60 regex
+    AN->>CL: strip_ansi plus classify 80 regex
     CL-->>AN: ClassifiedEvents plus counts
     AN->>AN: dedup to ranked ActionItems by sev times count
+    AN->>CA: timeline blast change-window
+    CA-->>AN: timeline / blast / change_window
     loop top-N action items
         AN->>SA: scrub context secrets and public IPs
         SA-->>AN: sanitized incident context
-        AN->>LK: query ollama to local to claude
+        AN->>LK: query ollama to local to claude to grok
         alt LLM available
             LK-->>AN: 5-phase JSON playbook
         else off or failed
@@ -152,7 +159,7 @@ sequenceDiagram
     end
     AN->>AN: health_score 0 to 100 plus grade plus exec summary
     AN-->>API: AnalysisResult JSON
-    API-->>OP: score, actions, CLI, topology
+    API-->>OP: score, actions, CLI, topology, timeline
 ```
 
 ---
@@ -206,20 +213,23 @@ the tool never hard-fails on a missing model.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Ollama: provider local
+    [*] --> Ollama: provider ollama
     Ollama --> DMR: no response
     DMR --> Claude: no response or no socket
-    Claude --> RuleKB: API error or disabled
+    Claude --> Grok: no response or no key
+    Grok --> RuleKB: API error or disabled
 
     Ollama --> Done: text returned
     DMR --> Done: text returned
     Claude --> Done: text returned
+    Grok --> Done: text returned
     RuleKB --> Done: deterministic playbook
 
     Done --> [*]
 
     note right of Ollama : port 11434 native api chat
     note right of DMR : Docker Model Runner port 12434 unix socket
+    note right of Grok : xAI OpenAI-compat, sanitize-first
     note right of RuleKB : kb.lookup always emits actionable output
 ```
 
@@ -286,6 +296,7 @@ flowchart TB
         SANITIZE["sanitize.py"]
         CLASSIFIER["classifier.py"]
         ANALYZER["analyzer.py"]
+        CAUSAL["causal.py - timeline, blast, change-window"]
     end
 
     subgraph INTEL["intelligence"]
@@ -301,6 +312,7 @@ flowchart TB
 
     SOURCES & ADAPTERS --> ANALYZER
     ANALYZER --> SANITIZE --> CLASSIFIER
+    ANALYZER --> CAUSAL
     ANALYZER --> LLM
     LLM -.fallback.-> KB
     ANALYZER --> SITE
@@ -311,7 +323,7 @@ flowchart TB
     classDef site fill:#059669,stroke:#34d399,color:#fff
 
     class SOURCES,ADAPTERS in
-    class SANITIZE,CLASSIFIER,ANALYZER pipe
+    class SANITIZE,CLASSIFIER,ANALYZER,CAUSAL pipe
     class LLM,KB ai
     class TOPO,OPT,EXTRA site
 ```
@@ -325,9 +337,9 @@ flowchart TB
 | **Language** | Python 3.10+ (frozen dataclasses, `typing.Protocol`, `re`) |
 | **Web / API** | Flask 3 · flask-cors · gunicorn · vanilla JS · Cytoscape.js + ELK |
 | **Ingest** | `requests` · raw AF_UNIX socket HTTP · `subprocess` (docker CLI) · optional tfsm-fire / TextFSM (upstream withdrawn 2026-07 — manual install only, see [TFSM_AUTO_PARSER.md](TFSM_AUTO_PARSER.md)) |
-| **Intelligence** | Ollama · Docker Model Runner (OpenAI-compat) · Anthropic Claude (`claude-haiku-4-5`) · rule-based KB |
+| **Intelligence** | Ollama · Docker Model Runner (OpenAI-compat) · Anthropic Claude (`claude-haiku-4-5`) · xAI Grok (`grok-4`) · rule-based KB |
 | **Security** | `hashlib` (sha256 stable tokens) · `ipaddress` · sanitize-before-LLM gate · X-API-Token · CORS allow-list |
-| **Agent surface** | MCP SDK (FastMCP, optional) over stdio / streamable-http |
+| **Agent surface** | MCP SDK 2.x (`MCPServer`, optional) over stdio / streamable-http |
 | **Packaging** | `pyproject.toml` console scripts (`ai-log-analyzer` / `netlog-ai`) · Docker · docker-compose |
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -351,7 +351,7 @@
   <section class="hero" id="hero" aria-label="Introduction">
     <div class="wrap hero-grid">
       <div class="hero-copy">
-        <span class="tagchip"><span class="spark" aria-hidden="true"></span>v0.5.2 · 0.6 in flight · local-first · sanitize-before-LLM</span>
+        <span class="tagchip"><span class="spark" aria-hidden="true"></span>v0.6.0 · causal console · sanitize-before-LLM</span>
         <h1 class="hero-title">netlog-ai</h1>
         <p class="hero-tag">Network logs in. <b>Ranked actions out.</b> A local, sanitize-first, multi-vendor AI log analyzer that turns raw syslog and CLI output into prioritized, copy-pastable root-cause playbooks.</p>
 
@@ -818,11 +818,11 @@ pytest --cov=src --cov-report=term-missing</pre>
   <section id="roadmap" aria-labelledby="road-h">
     <div class="wrap">
       <p class="eyebrow">Status + plan</p>
-      <h2 class="title" id="road-h">From 0.5.2 into 0.6</h2>
-      <p class="lead" style="margin-bottom:30px">v0.5.2 is the security-hardened tree on PyPI. 0.6 is the causal console: Grok as a first-class sanitize-first backend, a timeline of the incident, blast-radius, change-window correlation, a sanitize-diff viewer, a custom-rule editor, and SONiC + Cumulus classifier coverage.</p>
+      <h2 class="title" id="road-h">0.6.0 shipped · 0.7 next</h2>
+      <p class="lead" style="margin-bottom:30px">v0.6.0 is the causal console: Grok as a first-class sanitize-first backend, a timeline of the incident, blast-radius, change-window correlation, a sanitize-diff viewer, a custom-rule editor, and SONiC + Cumulus classifier coverage. 423 tests.</p>
       <div class="grid features">
-        <article class="card feat reveal"><div class="ico" aria-hidden="true">✓</div><h3>0.5.2 — shipped</h3><p>Fail-closed docker-exec allow-list, POP-scoped site prefixes, secret-sanitized template memory, incident-search API token, bounded custom regex, webhook payload sanitize. 369 tests at that tag.</p></article>
-        <article class="card feat reveal"><div class="ico" aria-hidden="true">▶</div><h3>0.6.0 — building</h3><p>Grok (xAI) provider, causal timeline, blast-radius estimator, change-window correlator, sanitize-diff API + UI, custom-rule editor, SONiC orchagent/syncd/swss/teamd + Cumulus clagd/switchd/NVUE patterns.</p></article>
+        <article class="card feat reveal"><div class="ico" aria-hidden="true">✓</div><h3>0.5.2 — shipped</h3><p>Fail-closed docker-exec allow-list, POP-scoped site prefixes, secret-sanitized template memory, incident-search API token, bounded custom regex, webhook payload sanitize.</p></article>
+        <article class="card feat reveal"><div class="ico" aria-hidden="true">✓</div><h3>0.6.0 — shipped</h3><p>Grok (xAI) provider, causal timeline, blast-radius estimator, change-window correlator, sanitize-diff API + UI, custom-rule editor, SONiC orchagent/syncd/swss/teamd + Cumulus clagd/switchd/NVUE/PTMD patterns.</p></article>
         <article class="card feat reveal"><div class="ico" aria-hidden="true">·</div><h3>0.7.0 — planned</h3><p>Multi-site comparison, Slack/Teams webhook simulator with redaction, cross-run Drain template UI, voice incident brief, PDF executive one-pager from the console.</p></article>
       </div>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netlog-ai"
-version = "0.5.2"
+version = "0.6.0"
 description = "AI-powered network syslog analyzer with pluggable LLM providers (local Docker Model Runner / Anthropic Claude / xAI Grok) and lab adapters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/ai_log_analyzer/__init__.py
+++ b/src/ai_log_analyzer/__init__.py
@@ -24,7 +24,7 @@ try:
     # old "ai-log-analyzer" lookup never matched and always hit the fallback.
     __version__: str = _pkg_version("netlog-ai")
 except _PkgNFE:
-    __version__ = "0.3.0"  # fallback for non-installed / editable dev checkouts
+    __version__ = "0.6.0"  # fallback for non-installed / editable dev checkouts
 
 
 # ── Env bootstrap (MUST run before submodule imports) ────────────────────────


### PR DESCRIPTION
## Summary

Cut **v0.6.0** as the public causal-console release. The analyzer code already landed in #35; this PR is the version bump, changelog, GitHub Pages copy, and architecture diagrams.

- `pyproject.toml` / `__version__` fallback → **0.6.0**
- CHANGELOG: `[0.6.0] - 2026-08-29`
- Pages (`docs/index.html`) hero + roadmap: **0.6.0 shipped · 0.7 next**
- README: What's new — 0.6 causal console
- ARCHITECTURE.md: `causal.py` on the pipeline map and analyze sequence; Grok in the provider chain; 80 patterns; MCPServer

PyPI is still **0.5.1**. There is no `v0.5.2` tag (0.5.2 was git-only). After merge, tag `v0.6.0` so `release.yml` publishes the wheel and GitHub release.

Hub card: gesh75/gesh75.github.io#11 (merged).

## Test plan

- [x] Hub card flipped off "in flight"
- [ ] CI green on 3.10 / 3.11 / 3.12
- [ ] After merge: `git tag v0.6.0 && git push origin v0.6.0`
- [ ] Pages at https://gesh75.github.io/netlog-ai/ shows v0.6.0 / 423 / 80, not zeros